### PR TITLE
[Hydrus] Add the mocap launch file in the onbard sensor list

### DIFF
--- a/robots/hydrus/launch/includes/euclid201806/sensors.launch.xml
+++ b/robots/hydrus/launch/includes/euclid201806/sensors.launch.xml
@@ -15,6 +15,9 @@
       <!-- realsense cameras & VIO in intel euclid -->
       <include file="$(find realsense_camera)/launch/lr200m_nodelet_default.launch" />
       <include file="$(find realsense_sp)/launch/sp.launch" />
+
+      <!-- mocap -->
+      <include file="$(find aerial_robot_base)/launch/external_module/mocap.launch" />
     </group>
   </group>
 


### PR DESCRIPTION
move the launch of about mocap from local pc to onboard processor, based on the new network system.