### PR TITLE
Improve the giambal controller for pitch and roll

### DIFF
--- a/robots/dragon/config/quad/GimbalControlConfig.yaml
+++ b/robots/dragon/config/quad/GimbalControlConfig.yaml
@@ -40,7 +40,8 @@ controller/yaw/i_gain: 0.1
 controller/yaw/d_gain: -5 # should be negative
 
 # pitch & roll
-controller/pitch_roll/control_rate_thresh: 0.35 #0.4 OK!
+controller/pitch_roll/control_p_det_thresh: 0.00025
+controller/pitch_roll/control_rate_thresh: 0.7
 controller/pitch_roll/limit: 20.0
 controller/pitch_roll/p_term_limit: 20.0
 controller/pitch_roll/i_term_limit: 20.0

--- a/robots/dragon/include/dragon/gimbal_control.h
+++ b/robots/dragon/include/dragon/gimbal_control.h
@@ -108,6 +108,7 @@ namespace control_plugin
 
     /* pitch roll control */
     double pitch_roll_control_rate_thresh_;
+    double pitch_roll_control_p_det_thresh_;
     tf::Vector3 pitch_roll_gains_;
     double pitch_roll_limit_;
     tf::Vector3 pitch_roll_terms_limits_;

--- a/robots/dragon/src/gimbal_control.cpp
+++ b/robots/dragon/src/gimbal_control.cpp
@@ -242,7 +242,8 @@ namespace control_plugin
 
     Eigen::VectorXd f;
 
-    if(P_det < 1e-3)
+    //ROS_INFO_THROTTLE(0.1, "P_det: %f", P_det);
+    if(P_det < pitch_roll_control_p_det_thresh_)
       { // bad pitch roll
         if(control_verbose_) ROS_ERROR("bad P_det: %f", P_det);
         P = Eigen::MatrixXd::Zero(3, rotor_num  * 2);
@@ -617,7 +618,10 @@ namespace control_plugin
     ros::NodeHandle pitch_roll_node(nhp_, "pitch_roll");
     string pitch_roll_ns = pitch_roll_node.getNamespace();
     pitch_roll_node.param("control_rate_thresh", pitch_roll_control_rate_thresh_, 1.0);
-    if(param_verbose_) cout << pitch_roll_ns << ": pos_limit_ is " <<  pitch_roll_control_rate_thresh_ << endl;
+    if(param_verbose_) cout << pitch_roll_ns << ": pitch_roll_control_rate_thresh_ is " <<  pitch_roll_control_rate_thresh_ << endl;
+    pitch_roll_node.param("control_p_det_thresh", pitch_roll_control_p_det_thresh_, 1e-3);
+    if(param_verbose_) cout << pitch_roll_ns << ": pitch_roll_control_p_det_thresh_ is " <<  pitch_roll_control_p_det_thresh_ << endl;
+
     pitch_roll_node.param("limit", pitch_roll_limit_, 1.0e6);
     if(param_verbose_) cout << pitch_roll_ns << ": pos_limit_ is " <<  pitch_roll_limit_ << endl;
     pitch_roll_node.param("p_term_limit", pitch_roll_terms_limits_[0], 1.0e6);


### PR DESCRIPTION
1. Change the thresh ptich_roll P matrix determinant as a parameter
 
https://github.com/tongtybj/aerial_robot/blob/a4d74f5ea8ca8da9bb1cd67481238374412154f0/robots/dragon/src/gimbal_control.cpp#L246

2. Current values about  following two parameters are not suitable for latest version dragon
- `pitch_roll_control_rate_thresh_`
- `pitch_roll_control_p_det_thresh_`
   
  1.   [`pitch_roll_control_p_det_thresh_ = 1e-3`](https://github.com/tongtybj/aerial_robot/blob/dragon_20180628/robots/dragon/src/gimbal_control.cpp#L245) is too high, leading to the less influence of gimbal control for pitch and roll. This value makes the gimbal control for pitch and roll does not involve in aerial transformation demo (model = 0) at all. This is also the reason, that why this demo (mode = 0) always makes the unexpected falling.
   2. [`pitch_roll_control_p_det_thresh_ =0.35` ]( https://github.com/tongtybj/aerial_robot/blob/dragon_20180628/robots/dragon/config/quad/GimbalControlConfig.yaml#L43) is too low, leading to the picky control output for pitch and roll. This is easy to understand from this [paper](https://ieeexplore.ieee.org/document/8258850/) (Eq.2), *`H2`* is associated with the relative height of each rotor, if this height is too low, the inversion of  *`H2`* will become big, since the existence of the height value in denominator. 
  3. the best values of these two parameters are:
https://github.com/tongtybj/aerial_robot/blob/a4d74f5ea8ca8da9bb1cd67481238374412154f0/robots/dragon/config/quad/GimbalControlConfig.yaml#L43-L44