### PR TITLE
Update the collision model of dragon link

### DIFF
--- a/robots/dragon/urdf/dragon_link.urdf.xacro
+++ b/robots/dragon/urdf/dragon_link.urdf.xacro
@@ -115,9 +115,9 @@
       -->
       <!-- cylinder collision geometry works well for FCL -->
       <collision>
-        <origin rpy="${pi/2} 0 0" xyz="${gimbal_roll_x_offset}  0 0"/>
+        <origin rpy="${pi/2} 0 0" xyz="0 0 0.02"/>
         <geometry>
-          <cylinder length="0.3" radius="0.08" />
+          <cylinder length="0.3" radius="0.09" />
         </geometry>
       </collision>
 


### PR DESCRIPTION
The collision model for the gimbal module is very crucial for the path planning methods, e.g., the squeezing motion based on differential kinematics. 

The previous model can not pad the ducted fan very well, as shown in following figure.
![dragon_old_collision_model](https://user-images.githubusercontent.com/3666095/45256664-9b047780-b3d4-11e8-8d02-bc020c4220a7.png)

By this PR, the new padding model is shown as follow.
![dragon_new_collision_model](https://user-images.githubusercontent.com/3666095/45256668-a657a300-b3d4-11e8-8fb3-d2d1451d584e.png)
