### PR TITLE
add api : setRotorDirection

### DIFF
--- a/aerial_robot_model/include/aerial_robot_model/transformable_aerial_robot_model.h
+++ b/aerial_robot_model/include/aerial_robot_model/transformable_aerial_robot_model.h
@@ -84,6 +84,7 @@ namespace aerial_robot_model {
     double getVerbose() const { return verbose_; }
     void setActuatorJointMap(const sensor_msgs::JointState& actuator_state);
     void setCogDesireOrientation(double roll, double pitch, double yaw) { cog_desire_orientation_ = KDL::Rotation::RPY(roll, pitch, yaw); }
+    void setRotorDirection(const std::map<int, int>& rotor_direction) { rotor_direction_ = rotor_direction; }
     bool removeExtraModule(std::string module_name);
     virtual void updateRobotModelImpl(const KDL::JntArray& joint_positions);
     void updateRobotModel(const KDL::JntArray& joint_positions) { updateRobotModelImpl(joint_positions); }


### PR DESCRIPTION
[ここ](https://github.com/tongtybj/aerial_robot/blob/master/aerial_robot_model/src/transformable_aerial_robot_model.cpp#L107)でロータの回転方向を取得するようになっていますが，これだと[0, 0, 1]か[0, 0, -1]でないと向きを取得できないので外部から変更できるAPIを追加しました．