### PR TITLE
[Dragon] remove the unecessary vel feed-back state approxiamtion for CoG control in gazebo

### DIFF
--- a/robots/dragon/src/gimbal_control.cpp
+++ b/robots/dragon/src/gimbal_control.cpp
@@ -93,9 +93,6 @@ namespace control_plugin
     servoTorqueProcess();
     stateError();
 
-    /* not good, but stable for gazebo */
-    if(simulation_) state_vel_ = estimator_->getVel(Frame::BASELINK, estimate_mode_);
-
     pidUpdate(); //LQI thrust control
     gimbalControl(); //gimbal vectoring control
     desireTilt();


### PR DESCRIPTION
The remove part was aimed to avoid the vibration noise from the baselink angular velocity while calculating the CoG velocity.

However, the current system shows there is few noisy in baselink angular velocity.
Therefore, no longer need this approximation