### PR TITLE
Update the version mocap

### DIFF
--- a/aerial_robot.rosinstall
+++ b/aerial_robot.rosinstall
@@ -14,7 +14,7 @@
 - git:
     local-name: mocap_optitrack
     uri: https://github.com/ros-drivers/mocap_optitrack.git
-    version: master
+    version: 9724d0e
 # mavlink
 # This should be temporary link, since this is fixed to be indigo version
 - git:


### PR DESCRIPTION
The version of mocap in windows PC is updated, so we have to update the responding mocap version in linux.