### PR TITLE
Update the behavior sensor's health check function

### DIFF
--- a/aerial_robot_base/include/aerial_robot_base/sensor_base_plugin.h
+++ b/aerial_robot_base/include/aerial_robot_base/sensor_base_plugin.h
@@ -200,14 +200,14 @@ namespace sensor_plugin
       health_stamp_.resize(chan_num, ros::Time::now().toSec());
     }
 
-    void updateHealthStamp(double stamp, uint8_t chan = 0)
+    void updateHealthStamp(uint8_t chan = 0)
     {
       if(!health_[chan])
         {
           health_[chan] = true;
-          ROS_WARN("%s: get sensor data, du: %f", nhp_.getNamespace().c_str(), stamp - health_stamp_[chan]);
+          ROS_WARN("%s: get sensor data, du: %f", nhp_.getNamespace().c_str(), ros::Time::now().toSec() - health_stamp_[chan]);
         }
-      health_stamp_[chan] = stamp;
+      health_stamp_[chan] = ros::Time::now().toSec();
     }
 
     inline const tf::Transform& getBaseLink2SensorTransform() const { return sensor_tf_; }

--- a/aerial_robot_base/src/sensor/altitude.cpp
+++ b/aerial_robot_base/src/sensor/altitude.cpp
@@ -424,7 +424,7 @@ namespace sensor_plugin
         }
 
       alt_pub_.publish(alt_state_);
-      updateHealthStamp(current_secs, 1); //channel: 1
+      updateHealthStamp(1); //channel: 1
     }
 
     void rangeEstimateProcess(ros::Time stamp)
@@ -603,7 +603,7 @@ namespace sensor_plugin
       prev_raw_baro_pos_z_ = raw_baro_pos_z_;
       prev_baro_pos_z_ = baro_pos_z_;
       prev_high_filtered_baro_pos_z_ = high_filtered_baro_pos_z_;
-      updateHealthStamp(current_secs, 0); //channel: 0
+      updateHealthStamp(0); //channel: 0
     }
 
     void baroEstimateProcess(ros::Time stamp)

--- a/aerial_robot_base/src/sensor/gps.cpp
+++ b/aerial_robot_base/src/sensor/gps.cpp
@@ -334,7 +334,7 @@ namespace sensor_plugin
 
         /* update */
         prev_raw_pos_ = raw_pos_;
-        updateHealthStamp(current_secs, 0); //channel: 1
+        updateHealthStamp(0); //channel0
 
         /* for wp control, not good */
         if(gps_msg->sat_num > min_wp_sat_num_)
@@ -444,7 +444,7 @@ namespace sensor_plugin
 
         /* update */
         prev_raw_rtk_pos_ = raw_rtk_pos_;
-        updateHealthStamp(current_secs, 1); //channel: 1
+        updateHealthStamp(1); //channel: 1
       }
 
       void wpCallback(const mavros_msgs::WaypointList::ConstPtr & msg)

--- a/aerial_robot_base/src/sensor/imu.cpp
+++ b/aerial_robot_base/src/sensor/imu.cpp
@@ -52,6 +52,14 @@
 using namespace Eigen;
 using namespace std;
 
+namespace
+{
+  int bias_calib = 0;
+  ros::Time prev_time;
+
+  bool first_callback = true;
+}
+
 namespace sensor_plugin
 {
   class Imu : public sensor_plugin::SensorBase
@@ -70,7 +78,7 @@ namespace sensor_plugin
 
     ~Imu () {}
     Imu ():
-      calib_count_(100),
+      calib_count_(200),
       acc_b_(0, 0, 0),
       euler_(0, 0, 0),
       omega_(0, 0, 0),
@@ -136,14 +144,11 @@ namespace sensor_plugin
         }
 
       imuDataConverter();
-      updateHealthStamp(imu_msg->stamp.toSec());
+      updateHealthStamp();
     }
 
     void imuDataConverter()
     {
-      static int bias_calib = 0;
-      static ros::Time prev_time;
-
       if(imu_stamp_.toSec() <= prev_time.toSec())
         {
           ROS_WARN("IMU: bad timestamp. curr time stamp: %f, prev time stamp: %f",
@@ -217,7 +222,7 @@ namespace sensor_plugin
         {
           bias_calib ++;
 
-          if(bias_calib == 2)
+          if(bias_calib == 100)
             {
               calib_count_ = calib_time_ / sensor_dt_;
               ROS_WARN("calib count is %d", calib_count_);

--- a/aerial_robot_base/src/sensor/mocap.cpp
+++ b/aerial_robot_base/src/sensor/mocap.cpp
@@ -198,7 +198,7 @@ namespace sensor_plugin
 
       previous_time = msg->header.stamp;
       /* consider the remote wirleess transmission, we use the local time server */
-      updateHealthStamp(ros::Time::now().toSec());
+      updateHealthStamp();
     }
 
     void groundTruthProcess()

--- a/aerial_robot_base/src/sensor/optical_flow.cpp
+++ b/aerial_robot_base/src/sensor/optical_flow.cpp
@@ -198,7 +198,7 @@ namespace sensor_plugin
 
       /* update */
       previous_secs = current_secs;
-      updateHealthStamp(current_secs);
+      updateHealthStamp();
     }
 
     void estimateProcess(ros::Time stamp)

--- a/aerial_robot_base/src/sensor/vo.cpp
+++ b/aerial_robot_base/src/sensor/vo.cpp
@@ -207,7 +207,7 @@ namespace sensor_plugin
       vo_state_pub_.publish(vo_state_);
 
       /* update */
-      updateHealthStamp(vo_msg->header.stamp.toSec());
+      updateHealthStamp();
     }
 
     void estimateProcess(ros::Time stamp)


### PR DESCRIPTION
1. The sensor's time stamp is used to update the health checker for each sensor plugin. But sensors from rosserial have no synchronized time stamp with ros system. Therefore, the time stamp of ros system when the new sensor date is received is applied for the health checker. 

2. IMU data from rosserial has bad frequency for the initial duration (~0.01s). Therefore the calibration process should not start right after receiving the IMU data. The delay (i.e. 100 samples) is applied in order to execute when the sensor frequency is stable.
