### PR TITLE
Add the gimbal vectoring test based on the desired tilt

### DIFF
--- a/robots/dragon/config/quad/GimbalControlConfig.yaml
+++ b/robots/dragon/config/quad/GimbalControlConfig.yaml
@@ -49,3 +49,6 @@ controller/pitch_roll/d_gain: 0.5 #pitch big noise from gyro
 
 # desire tilt
 controller/tilt_pub_interval: 0.2
+
+# gimbal vectoring function check
+controller/gimbal_vectoring_check_flag: false

--- a/robots/dragon/include/dragon/gimbal_control.h
+++ b/robots/dragon/include/dragon/gimbal_control.h
@@ -107,6 +107,7 @@ namespace control_plugin
     tf::Vector3 pitch_roll_terms_limits_;
     double roll_i_term_, pitch_i_term_;
     double gimbal_control_stamp_;
+    bool gimbal_vectoring_check_flag_;
 
     /* landing process */
     bool level_flag_;


### PR DESCRIPTION
Revive the test  on the gimbal vectoring control according to the desired CoG tilt attitude.

related to the discussion in #175 : 

> DragonTransformControllerのgimbal_control_pub_は必要ですか？
> gimbal_control = falseでいつも使っているので使われていないみたいですが
> https://github.com/tongtybj/aerial_robot/blob/devel/robots/dragon/src/transform_control.cpp#L69
> これはRobotModel(DragonRobotModel)に入れるべき関数だと思われるのですがROS依存になってしまっているのでそういうことでおねがいします．いったん消します．
