### PR TITLE
remove the voltage divider

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/battery_status/battery_status.h
+++ b/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/battery_status/battery_status.h
@@ -24,7 +24,6 @@
 #define ROS_PUB_INTERVAL 100 //20[ms]; 500[ms]
 /* https://www.sparkfun.com/datasheets/Sensors/DC%20Voltage%20and%20Current%20Sense%20PCB%20Spec%20Sheet.pdf */
 #define ADC_SCALE 12.65f * 0.001f // [mV/bit] for 12bit 3.3V ADC
-#define VOLTAGE_DIVISION 6
 
 class BatteryStatus
 {
@@ -57,7 +56,7 @@ public:
         	adc_value_ = HAL_ADC_GetValue(hadc_);
         HAL_ADC_Start(hadc_);
 
-        float voltage =  adc_value_ * ADC_SCALE * VOLTAGE_DIVISION ;
+        float voltage =  adc_value_ * ADC_SCALE;
         if(voltage_ < 0) voltage_ = voltage;
 
         /* filtering */


### PR DESCRIPTION
In the former ADC, the external resisters are used to the voltage division, leading to the poor accuracy about voltage measurement.

Remove the voltage divider, by taking off the registers as shown in the figure.
![2018-12-05 22 48 03](https://user-images.githubusercontent.com/3666095/49524325-e6082b00-f8ee-11e8-9de4-b1af22ce2ed5.jpg)
