### PR TITLE
Fix bug about joint PID control in gazebo: add the i term range for each robot.

### DIFF
--- a/robots/dragon/config/quad/Servo.yaml
+++ b/robots/dragon/config/quad/Servo.yaml
@@ -11,7 +11,7 @@ dragon:
 
       # for simulation
       simulation:
-        pid: {p: 50.0, i: 0.01, d: 2.0}
+        pid: {p: 50.0, i: 0.01, d: 2.0, i_clamp_max: 1.0, i_clamp_min: -1.0}
         init_value: 0
         type: effort_controllers/JointPositionController
 

--- a/robots/hydrus/config/hex/Servo.yaml
+++ b/robots/hydrus/config/hex/Servo.yaml
@@ -11,7 +11,7 @@ hydrusx:
 
       # for simulation
       simulation:
-        pid: {p: 50.0, i: 0.01, d: 2.0}
+        pid: {p: 50.0, i: 0.01, d: 2.0, i_clamp_max: 1.0, i_clamp_min: -1.0}
         init_value: 1.047
         type: effort_controllers/JointPositionController
 

--- a/robots/hydrus/config/quad/Servo.yaml
+++ b/robots/hydrus/config/quad/Servo.yaml
@@ -11,7 +11,7 @@ hydrusx:
 
       # for simulation
       simulation:
-        pid: {p: 50.0, i: 0.01, d: 2.0}
+        pid: {p: 50.0, i: 0.01, d: 2.0, i_clamp_max: 1.0, i_clamp_min: -1.0}
         init_value: 1.57
         type: effort_controllers/JointPositionController
 

--- a/robots/hydrus/config/sensors/vo/zed_mini.yaml
+++ b/robots/hydrus/config/sensors/vo/zed_mini.yaml
@@ -33,7 +33,7 @@ hydrusx:
 
       # for simulation
       simulation:
-        pid: {p: 10.0, i: 0.01, d: 0.0}
+        pid: {p: 10.0, i: 0.01, d: 0.0, i_clamp_max: 0.1, i_clamp_min: -0.1}
         init_value: 0 # -1.570796
         type: effort_controllers/JointPositionController
 


### PR DESCRIPTION
So far, the i control for joint in gazebo is not activated, since the i term range is [-0, 0].
**This is a big bug!!!**

I tried to add the rough range for each robot: hydrus and dragon.

@KahnShi  Please tune the parameter for hydrus
@chibi314 Please update your hydrus_xi 
