### PR TITLE
Refactor the function "DragonRobotModel::updateRobotModelImpl"

### DIFF
--- a/robots/dragon/include/dragon/dragon_robot_model.h
+++ b/robots/dragon/include/dragon/dragon_robot_model.h
@@ -72,7 +72,6 @@ private:
 
   //private functions
   void getParamFromRos();
-  KDL::JntArray gimbalProcess(const KDL::JntArray& joint_positions);
 };
 
 template<> inline KDL::JntArray DragonRobotModel::getGimbalProcessedJoint() const


### PR DESCRIPTION
[```Dragon::updateRobotModelImpl```](https://github.com/tongtybj/aerial_robot/blob/1.0.3/robots/dragon/src/dragon_robot_model.cpp#L81-L101) の処理時間が[以前の非公式バージョン](https://github.com/tongtybj/aerial_robot/tree/dragon_20180910)の約2倍になっていたので、調査してみた。

原因は[```RobotModel::forwardKinematicsImpl```](https://github.com/tongtybj/aerial_robot/blob/1.0.3/aerial_robot_model/include/aerial_robot_model/transformable_aerial_robot_model.h#L127-L138 )が呼ばれるたびに、中で[```KDL::TreeFkSolverPos_recursive fk_solver```](https://github.com/tongtybj/aerial_robot/blob/1.0.3/aerial_robot_model/include/aerial_robot_model/transformable_aerial_robot_model.h#L132)が実行されるわけだが、
KDLのAPI referenceを見ると、```KDL::TreeFkSolverPos_recursive```で、```addTree()```という再帰関数を含む超重そうな関数が実行される。

- https://github.com/orocos/orocos_kinematics_dynamics/blob/master/orocos_kdl/src/treefksolverpos_recursive.cpp#L28-L31
- https://github.com/orocos/orocos_kinematics_dynamics/blob/master/orocos_kdl/src/tree.cpp#L34-L42

つまり、```KDL::TreeFkSolverPos_recursive```の繰り返し生成は極力避けるべきで、```KDL::Tree```が変わらなれば、　
https://github.com/tongtybj/aerial_robot/blob/bdc24e932a588cadc6dd86e33b4c7072715aa480/robots/dragon/src/dragon_robot_model.cpp#L64
のように共通のものを最初に宣言しておけばいいと思う。
結果、```Dragon::updateRobotModelImpl```の処理時間は半分に戻った、もしくはもっと短くなった(他のAPIの改善により)

なお、上記の問題とこの対処方法はDragonといったジンバル機構角度が関節角度依存の時に当てはまるため、他の種類の機体(hydrus, hydrus_XI)ではまず問題が起きないので、```DragonRobotModel```内で修正を加えてみた。
