### PR TITLE
[Fix Bug] The storage order  from array to Eigen::Matrix

### DIFF
--- a/aerial_robot_model/include/aerial_robot_model/kdl_utils.h
+++ b/aerial_robot_model/include/aerial_robot_model/kdl_utils.h
@@ -73,7 +73,7 @@ namespace aerial_robot_model {
 
   inline Eigen::Matrix3d kdlToEigen(const KDL::Rotation& in)
   {
-    return Eigen::Map<const Eigen::Matrix3d>(in.data);
+    return Eigen::Map<const Eigen::Matrix<double, 3, 3, Eigen::RowMajor> >(in.data);
   }
 
   inline std::vector<Eigen::Vector3d> kdlToEigen(const std::vector<KDL::Vector>& in)


### PR DESCRIPTION
The data array of matrix in KDL (e.g. KDL::Rotation) is column-major (make sense).
However, `If the storage order is not specified, then Eigen defaults to storing the entry in column-major.`

Please refer to https://eigen.tuxfamily.org/dox/group__TopicStorageOrders.html

So, we have to explicitly set the mapping order from KDL data array to Eigen::Matrix,
`KDL::RotationalInertia` is Symmetric matrix, so no change.

Another point is  that `<const Eigen::Matrix3d, Eigen::RowMajor>` does not work.
