### PR TITLE
Add actuators (e.g. joint, gimbal) disable process in force landing phase

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/Hydrus_Lib/Spine/spine.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/Hydrus_Lib/Spine/spine.cpp
@@ -12,7 +12,7 @@ namespace Spine
   /* CAUTIONS: be careful about the order of the var definition and func definition */
   namespace
   {
-  	std::vector<Neuron> neuron_;
+    std::vector<Neuron> neuron_;
     CANMotorSendDevice can_motor_send_device_;
     std::vector<std::reference_wrapper<Servo>> servo_;
     std::vector<std::reference_wrapper<Servo>> servo_with_send_flag_;
@@ -26,7 +26,7 @@ namespace Spine
     /* sensor fusion */
     StateEstimate* estimator_;
 
-  /* ros */
+    /* ros */
     constexpr uint8_t SERVO_PUB_INTERVAL = 20; //[ms]
     spinal::ServoStates servo_state_msg_;
     ros::Publisher servo_state_pub_("/servo/states", &servo_state_msg_);
@@ -45,6 +45,7 @@ namespace Spine
     ros::NodeHandle* nh_;
     uint32_t last_pub_time_;
     unsigned int can_idle_count_ = 0;
+    bool servo_control_flag_ = true;
   }
 
   void boardInfoCallback(const spinal::GetBoardInfo::Request& req, spinal::GetBoardInfo::Response& res)
@@ -54,6 +55,7 @@ namespace Spine
 
   void servoControlCallback(const spinal::ServoControlCmd& control_msg)
   {
+          if (!servo_control_flag_) return;
 	  if (control_msg.index_length != control_msg.angles_length) return;
 	  for (unsigned int i = 0; i < control_msg.index_length; i++) {
 		  servo_.at(control_msg.index[i]).get().setGoalPosition(control_msg.angles[i]);
@@ -263,6 +265,11 @@ namespace Spine
   int8_t getUavModel()
   {
 	  return uav_model_;
+  }
+
+  void setServoControlFlag(bool flag)
+  {
+          servo_control_flag_ = flag;
   }
 
   void convertGyroFromJointvalues()

--- a/aerial_robot_nerve/spinal/mcu_project/Hydrus_Lib/Spine/spine.h
+++ b/aerial_robot_nerve/spinal/mcu_project/Hydrus_Lib/Spine/spine.h
@@ -46,6 +46,7 @@ namespace Spine
   void convertGyroFromJointvalues();
   uint8_t getSlaveNum();
   int8_t getUavModel();
+  void setServoControlFlag(bool flag);
   void servoControlCallback(const spinal::ServoControlCmd& control_msg);
   void servoTorqueControlCallback(const spinal::ServoTorqueCmd& control_msg);
   void boardInfoCallback(const spinal::GetBoardInfo::Request& req, spinal::GetBoardInfo::Response& res);

--- a/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/flight_control/attitude/attitude_control.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/flight_control/attitude/attitude_control.cpp
@@ -218,7 +218,7 @@ void AttitudeController::update(void)
 #else
           nh_->logerror("failsafe1");
 #endif
-          force_landing_flag_ = true;
+          setForceLandingFlag(true);
         }
 
       /* should be virutal coord */
@@ -241,7 +241,7 @@ void AttitudeController::update(void)
 #else
           nh_->logerror("failsafe3");
 #endif
-          force_landing_flag_ = true;
+          setForceLandingFlag(true);
           error_angle_i_[X] = 0;
           error_angle_i_[Y] = 0;
         }
@@ -479,7 +479,7 @@ void AttitudeController::fourAxisCommandCallback( const spinal::FourAxisCommand 
   /* failsafe2-1: if the pitch and roll angle is too big, start force landing */
   if(fabs(target_angle_[X]) > MAX_TILT_ANGLE || fabs(target_angle_[Y]) > MAX_TILT_ANGLE )
     {
-      force_landing_flag_ = true;
+      setForceLandingFlag(true);
 #ifdef SIMULATION
       ROS_ERROR("failsafe2-1");
 #else
@@ -518,7 +518,7 @@ void AttitudeController::fourAxisCommandCallback( const spinal::FourAxisCommand 
       /* difference large than 90% of the max f */
       if(max_thrust - min_thrust > max_thrust_ * 0.9)
         {
-          force_landing_flag_ = true;
+          setForceLandingFlag(true);
 #ifdef SIMULATION
           ROS_ERROR("failsafe2-2");
 #else
@@ -540,7 +540,7 @@ void AttitudeController::fourAxisCommandCallback( const spinal::FourAxisCommand 
             if(abs(cmd_msg.angles[Z]) + cmd_msg.base_throttle[Z]  > max_thrust_ ||
                -abs(cmd_msg.angles[Z]) + cmd_msg.base_throttle[Z]  < min_thrust_)
               {
-                force_landing_flag_ = true;
+                setForceLandingFlag(true);
 #ifdef SIMULATION
                 ROS_ERROR("failsafe2-2");
 #else

--- a/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/flight_control/attitude/attitude_control.h
+++ b/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/flight_control/attitude/attitude_control.h
@@ -99,7 +99,15 @@ public:
   void setMotorNumber(uint8_t motor_number);
   void setPwmTestMode(bool pwm_test_flag){pwm_test_flag_ = pwm_test_flag; }
   void setIntegrateFlag(bool integrate_flag){integrate_flag_ = integrate_flag; }
-  void setForceLandingFlag(bool force_landing_flag){force_landing_flag_ = force_landing_flag;}
+  void setForceLandingFlag(bool force_landing_flag)
+  {
+    force_landing_flag_ = force_landing_flag;
+
+#ifdef NERVE_COMM
+    Spine::setServoControlFlag(!force_landing_flag);
+#endif
+
+  }
   float getPwm(uint8_t index) {return target_pwm_[index];}
   float getForce(uint8_t index) {return target_thrust_[index];}
   void levelPGain(float torque_p_gain) { torque_p_gain_[X] = torque_p_gain; torque_p_gain_[Y] = torque_p_gain;}


### PR DESCRIPTION
force landingに入ったあと、spinal側でプロペラ推力の受付をストップするようにしているけど、
関節やジンバルに関しては通常どおり指令を受けるようになっているので、
着地後も関節が動き続けたり、ジンバルが暴れたりして、故障の原因となっている。

このPRではspinalの方でforce landingフラグをチェックして、
https://github.com/tongtybj/aerial_robot/blob/b39691c8ca7a1b28366143e8c4c8977d9f75056d/aerial_robot_nerve/spinal/mcu_project/Hydrus_Lib/Spine/spine.cpp#L58
のように指令を遮断しているけど、
 [aerial_robot_model/servo_bridge](https://github.com/tongtybj/aerial_robot/blob/master/aerial_robot_model/src/servo_bridge.cpp)の方で実装する方法も考えられる。

spinalの方で実装した理由としては、 `attitude_control`との連動という観点でこのほうが一番合理的という点が挙げられる。
