### PR TITLE
Fix bug: wrong RGB alignment of depth cloud

### DIFF
--- a/robots/hydrus/robots/onboards/tx2_zed_201810/onboards.gazebo.xacro
+++ b/robots/hydrus/robots/onboards/tx2_zed_201810/onboards.gazebo.xacro
@@ -37,7 +37,7 @@
         <image>
           <width>1280</width>
           <height>720</height>
-          <format>R8G8B8</format>
+          <format>RGB</format>
         </image>
         <clip>
           <near>0.02</near>


### PR DESCRIPTION
以前から点群のRGBが入れ替わるということがあったのですが、これで治りました。
仕組みはよくわかっていませんが。