### PR TITLE
Fix bug: rosservice call sometimes fails

### DIFF
--- a/aerial_robot_nerve/spinal_ros_bridge/src/serial_node.cpp
+++ b/aerial_robot_nerve/spinal_ros_bridge/src/serial_node.cpp
@@ -51,6 +51,7 @@ int main(int argc, char* argv[])
   // Run boost::asio io service in a background thread.
   boost::asio::io_service io_service;
   new rosserial_server::SerialSession(io_service, port, baud);
+  ros::Duration(0.5).sleep();
   boost::thread(boost::bind(&boost::asio::io_service::run, &io_service));
 
   ros::MultiThreadedSpinner spinner(2);


### PR DESCRIPTION
`serial.launch`を立ち上げたとき、確率的に(体感30%くらい？)rosserviceが正しく立ち上がらないという問題があった．
対症療法だがdelayを挟むことで直った．