### PR TITLE
Fix the bug:  last two arguments of "findRotOmega" should be called by reference.

### DIFF
--- a/aerial_robot_base/include/aerial_robot_base/state_estimation.h
+++ b/aerial_robot_base/include/aerial_robot_base/state_estimation.h
@@ -271,7 +271,7 @@ public:
     }
   }
 
-  bool findRotOmege(const double timestamp, const int mode, tf::Matrix3x3 r, tf::Vector3 omega)
+  bool findRotOmega(const double timestamp, const int mode, tf::Matrix3x3& r, tf::Vector3& omega)
   {
     boost::lock_guard<boost::mutex> lock(queue_mutex_);
 
@@ -290,8 +290,7 @@ public:
 
     if(timestamp > timestamp_qu_.back())
       {
-        ROS_ERROR("estimation: sensor timestamp %f is later than the latest timestamp %f in queue",
-                  timestamp, timestamp_qu_.front());
+        ROS_ERROR("estimation: sensor timestamp %f is later than the latest timestamp %f in queue", timestamp, timestamp_qu_.back());
         return false;
       }
 

--- a/aerial_robot_base/src/sensor/gps.cpp
+++ b/aerial_robot_base/src/sensor/gps.cpp
@@ -200,7 +200,7 @@ namespace sensor_plugin
     tf::Matrix3x3 r; r.setIdentity();
     tf::Vector3 omega(0,0,0);
     int mode = StateEstimator::EGOMOTION_ESTIMATE;
-    estimator_->findRotOmege(curr_timestamp_, mode, r, omega);
+    estimator_->findRotOmega(curr_timestamp_, mode, r, omega);
     raw_vel_ += r * (- omega.cross(sensor_tf_.getOrigin())); //offset from gps to baselink
     raw_pos_ = world_frame_ * Gps::wgs84ToNedLocalFrame(home_wgs84_point_, curr_wgs84_point_) - r * sensor_tf_.getOrigin();
 

--- a/aerial_robot_base/src/sensor/vo.cpp
+++ b/aerial_robot_base/src/sensor/vo.cpp
@@ -279,7 +279,7 @@ namespace sensor_plugin
     tf::Matrix3x3 r;
     tf::Vector3 omega;
     int mode = estimator_->getStateStatus(State::YAW_BASE, StateEstimator::GROUND_TRUTH)?StateEstimator::GROUND_TRUTH:StateEstimator::EGOMOTION_ESTIMATE;
-    estimator_->findRotOmege((curr_timestamp_ + prev_timestamp_) / 2, mode, r, omega);
+    estimator_->findRotOmega((curr_timestamp_ + prev_timestamp_) / 2, mode, r, omega);
 
     raw_global_vel_ = r * ( sensor_tf_.getBasis() * raw_local_vel - omega.cross(sensor_tf_.getOrigin()));
 


### PR DESCRIPTION
This function is for the sensor which has older timestamp than imu-based robot tiemstamp.
The last two arguments: `tf::Matrix3x3& r, tf::Vector3& omega` should be called by reference.