### PR TITLE
Fix bug to find the synchronized rotation and angular velocity of baselink

### DIFF
--- a/aerial_robot_base/include/aerial_robot_base/state_estimation.h
+++ b/aerial_robot_base/include/aerial_robot_base/state_estimation.h
@@ -271,27 +271,28 @@ public:
     }
   }
 
-  bool findRotOmege(const double timestamp, const int mode, tf::Matrix3x3 r, tf::Vector3 omega)
+  bool findRotOmega(const double timestamp, const int mode, tf::Matrix3x3& r, tf::Vector3& omega, bool verbose = true)
   {
     boost::lock_guard<boost::mutex> lock(queue_mutex_);
 
     if(timestamp_qu_.size() == 0)
       {
-        ROS_ERROR("estimation: no valid queue for timestamp to find proper r and omega");
+        ROS_ERROR_COND(verbose, "estimation: no valid queue for timestamp to find proper r and omega");
+
         return false;
       }
 
     if(timestamp < timestamp_qu_.front())
       {
-        ROS_ERROR("estimation: sensor timestamp %f is earlier than the oldest timestamp %f in queue",
-                  timestamp, timestamp_qu_.front());
+        ROS_ERROR_COND(verbose, "estimation: sensor timestamp %f is earlier than the oldest timestamp %f in queue",
+                       timestamp, timestamp_qu_.front());
         return false;
       }
 
     if(timestamp > timestamp_qu_.back())
       {
-        ROS_ERROR("estimation: sensor timestamp %f is later than the latest timestamp %f in queue",
-                  timestamp, timestamp_qu_.front());
+        ROS_ERROR_COND(verbose, "estimation: sensor timestamp %f is later than the latest timestamp %f in queue", timestamp, timestamp_qu_.back());
+
         return false;
       }
 

--- a/aerial_robot_base/src/sensor/gps.cpp
+++ b/aerial_robot_base/src/sensor/gps.cpp
@@ -200,7 +200,9 @@ namespace sensor_plugin
     tf::Matrix3x3 r; r.setIdentity();
     tf::Vector3 omega(0,0,0);
     int mode = StateEstimator::EGOMOTION_ESTIMATE;
-    estimator_->findRotOmege(curr_timestamp_, mode, r, omega);
+    estimator_->findRotOmega(curr_timestamp_, mode, r, omega);
+    if(omega == tf::Vector3(0,0,0)) ROS_ERROR("gps: the omega is not updated from findRotOmega");
+
     raw_vel_ += r * (- omega.cross(sensor_tf_.getOrigin())); //offset from gps to baselink
     raw_pos_ = world_frame_ * Gps::wgs84ToNedLocalFrame(home_wgs84_point_, curr_wgs84_point_) - r * sensor_tf_.getOrigin();
 

--- a/aerial_robot_base/src/sensor/vo.cpp
+++ b/aerial_robot_base/src/sensor/vo.cpp
@@ -279,7 +279,7 @@ namespace sensor_plugin
     tf::Matrix3x3 r;
     tf::Vector3 omega;
     int mode = estimator_->getStateStatus(State::YAW_BASE, StateEstimator::GROUND_TRUTH)?StateEstimator::GROUND_TRUTH:StateEstimator::EGOMOTION_ESTIMATE;
-    estimator_->findRotOmege((curr_timestamp_ + prev_timestamp_) / 2, mode, r, omega);
+    estimator_->findRotOmega((curr_timestamp_ + prev_timestamp_) / 2, mode, r, omega);
 
     raw_global_vel_ = r * ( sensor_tf_.getBasis() * raw_local_vel - omega.cross(sensor_tf_.getOrigin()));
 


### PR DESCRIPTION
 last two arguments of `findRotOmega` should be called by reference.