### PR TITLE
Implement dynamixel TTL and RS485 mixed mode

### DIFF
--- a/aerial_robot_nerve/neuron/neuron_f4/neuronlib/CAN/can_constants.h
+++ b/aerial_robot_nerve/neuron/neuron_f4/neuronlib/CAN/can_constants.h
@@ -47,6 +47,7 @@ namespace CAN {
 	constexpr uint8_t BOARD_CONFIG_SET_SEND_DATA_FLAG = 5;
 	constexpr uint8_t BOARD_CONFIG_SET_SERVO_CURRENT_LIMIT = 6;
 	constexpr uint8_t BOARD_CONFIG_REBOOT = 7;
+	constexpr uint8_t BOARD_CONFIG_SET_DYNAMIXEL_TTL_RS485_MIXED = 8;
 }
 
 

--- a/aerial_robot_nerve/neuron/neuron_f4/neuronlib/Initializer/initializer.cpp
+++ b/aerial_robot_nerve/neuron/neuron_f4/neuronlib/Initializer/initializer.cpp
@@ -18,7 +18,8 @@ void Initializer::sendBoardConfig()
 	uint8_t data[8];
 	data[0] = servo_.servo_handler_.getServoNum();
 	data[1] = imu_.send_data_flag_ ? 1 : 0;
-	setMessage(CAN::MESSAGEID_SEND_INITIAL_CONFIG_0, m_slave_id, 2, data);
+	data[2] = servo_.servo_handler_.getTTLRS485Mixed();
+	setMessage(CAN::MESSAGEID_SEND_INITIAL_CONFIG_0, m_slave_id, 3, data);
 	sendMessage(1);
 	for (unsigned int i = 0; i < servo_.servo_handler_.getServoNum(); i++) {
 		const ServoData& s = servo_.servo_handler_.getServo()[i];
@@ -124,6 +125,13 @@ void Initializer::receiveDataCallback(uint8_t message_id, uint32_t DLC, uint8_t*
 		case CAN::BOARD_CONFIG_REBOOT:
 		{
 			NVIC_SystemReset();
+			break;
+		}
+		case CAN::BOARD_CONFIG_SET_DYNAMIXEL_TTL_RS485_MIXED:
+		{
+			servo_.servo_handler_.setTTLRS485Mixed(data[1]);
+			Flashmemory::erase();
+			Flashmemory::write();
 			break;
 		}
 		default:

--- a/aerial_robot_nerve/neuron/neuron_f4/neuronlib/Servo/Dynamixel/dynamixel_serial.h
+++ b/aerial_robot_nerve/neuron/neuron_f4/neuronlib/Servo/Dynamixel/dynamixel_serial.h
@@ -314,6 +314,8 @@ public:
   void setCurrentLimit(uint8_t servo_index);
   void update();
   unsigned int getServoNum() const {return servo_num_;}
+  uint16_t getTTLRS485Mixed() const {return ttl_rs485_mixed_;}
+  void setTTLRS485Mixed(uint16_t flag) {ttl_rs485_mixed_ = flag;}
   std::array<ServoData, MAX_SERVO_NUM>& getServo() {return servo_;}
   const std::array<ServoData, MAX_SERVO_NUM>& getServo() const {return servo_;}
 
@@ -323,6 +325,7 @@ private:
   RingBuffer<std::pair<uint8_t, uint8_t>, 16> instruction_buffer_;
   unsigned int servo_num_;
   std::array<ServoData, MAX_SERVO_NUM> servo_;
+  uint16_t ttl_rs485_mixed_;
 
   void transmitInstructionPacket(uint8_t id, uint16_t len, uint8_t instruction, uint8_t* parameters);
   int8_t readStatusPacket(void);
@@ -334,6 +337,15 @@ private:
   void cmdSyncRead(uint16_t address, uint16_t byte_size);
   void cmdSyncWrite(uint16_t address, uint8_t* param, int param_len);
 
+  inline void cmdReadCurrentLimit(uint8_t servo_index);
+  inline void cmdReadHardwareErrorStatus(uint8_t servo_index);
+  inline void cmdReadHomingOffset(uint8_t servo_index);
+  inline void cmdReadMoving(uint8_t servo_index);
+  inline void cmdReadPositionGains(uint8_t servo_index);
+  inline void cmdReadPresentCurrent(uint8_t servo_index);
+  inline void cmdReadPresentPosition(uint8_t servo_index);
+  inline void cmdReadPresentTemperature(uint8_t servo_index);
+  inline void cmdReadProfileVelocity(uint8_t servo_index);
   inline void cmdWriteCurrentLimit(uint8_t servo_index);
   inline void cmdWriteHomingOffset(uint8_t servo_index);
   inline void cmdWritePositionGains(uint8_t servo_index);

--- a/aerial_robot_nerve/spinal/mcu_project/Hydrus_Lib/CANDevice/servo/can_servo.h
+++ b/aerial_robot_nerve/spinal/mcu_project/Hydrus_Lib/CANDevice/servo/can_servo.h
@@ -54,13 +54,16 @@ class CANServo : public CANDevice
 {
 public:
 	CANServo(){}
-	CANServo(uint8_t slave_id, unsigned int servo_num):CANDevice(CAN::DEVICEID_SERVO, slave_id), servo_(servo_num){}
+	CANServo(uint8_t slave_id, unsigned int servo_num, bool dynamixel_ttl_rs485_mixed):CANDevice(CAN::DEVICEID_SERVO, slave_id), servo_(servo_num), dynamixel_ttl_rs485_mixed_(dynamixel_ttl_rs485_mixed){}
 	void setServoNum(unsigned int servo_num) {servo_.resize(servo_num);}
 	void sendServoConfigRequest();
 	void sendData() override;
 	void receiveDataCallback(uint8_t slave_id, uint8_t message_id, uint32_t DLC, uint8_t* data) override;
 	std::vector<Servo> servo_;
+	bool getDynamixelTTLRS485Mixed() const {return dynamixel_ttl_rs485_mixed_;}
+	void setDynamixelTTLRS485Mixed(bool dynamixel_ttl_rs485_mixed) {dynamixel_ttl_rs485_mixed_ = dynamixel_ttl_rs485_mixed;}
 private:
+	bool dynamixel_ttl_rs485_mixed_;
 	struct CANServoData{
 		int16_t angle;
 		uint8_t temperature;

--- a/aerial_robot_nerve/spinal/mcu_project/Hydrus_Lib/Spine/spine.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/Hydrus_Lib/Spine/spine.cpp
@@ -59,6 +59,7 @@ namespace Spine
 		  Neuron& neuron = neuron_.at(i);
 		  spinal::BoardInfo& board = board_info_res_.boards[i];
 		  board.imu_send_data_flag = neuron.can_imu_.getSendDataFlag() ? 1 : 0;
+		  board.dynamixel_ttl_rs485_mixed = neuron.can_servo_.getDynamixelTTLRS485Mixed() ? 1 : 0;
 		  board.slave_id = neuron.getSlaveId();
 
 		  for (unsigned int j = 0; j < board.servos_length; j++) {
@@ -99,7 +100,11 @@ namespace Spine
 
   void boardConfigCallback(const spinal::SetBoardConfig::Request& req, spinal::SetBoardConfig::Response& res)
   {
-	  can_idle_count_ = 2000;
+	  can_idle_count_ = 3000;
+	  //need this cheap delay
+	  for (int i = 0; i < 1000000; ++i) {
+			  asm("nop");
+	  }
 	  can_initializer_.configDevice(req);
 	  res.success = true;
   }

--- a/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/CAN/can_constants.h
+++ b/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/CAN/can_constants.h
@@ -47,6 +47,7 @@ namespace CAN {
 	constexpr uint8_t BOARD_CONFIG_SET_SEND_DATA_FLAG = 5;
 	constexpr uint8_t BOARD_CONFIG_SET_SERVO_CURRENT_LIMIT = 6;
 	constexpr uint8_t BOARD_CONFIG_REBOOT = 7;
+	constexpr uint8_t BOARD_CONFIG_SET_DYNAMIXEL_TTL_RS485_MIXED = 8;
 }
 
 

--- a/aerial_robot_nerve/spinal/msg/BoardInfo.msg
+++ b/aerial_robot_nerve/spinal/msg/BoardInfo.msg
@@ -1,3 +1,4 @@
 uint8 slave_id
 uint8 imu_send_data_flag
+uint8 dynamixel_ttl_rs485_mixed
 spinal/ServoInfo[] servos

--- a/aerial_robot_nerve/spinal/src/board_configurator/board_configurator.py
+++ b/aerial_robot_nerve/spinal/src/board_configurator/board_configurator.py
@@ -123,6 +123,7 @@ class BoardConfigurator(Plugin):
                 board.setFlags(board.flags() ^ Qt.ItemIsEditable)
                 board.appendRow([QStandardItem('board_id'), QStandardItem(str(b.slave_id))])
                 board.appendRow([QStandardItem('imu_send_data_flag'), QStandardItem(str(bool(b.imu_send_data_flag)))])
+                board.appendRow([QStandardItem('dynamixel_ttl_rs485_mixed'), QStandardItem(str(bool(b.dynamixel_ttl_rs485_mixed)))])
                 servos = QStandardItem('servo (' + str(len(b.servos)) + ')')
                 for j, s in enumerate(b.servos):
                     servo = QStandardItem(str(j))
@@ -154,7 +155,7 @@ class BoardConfigurator(Plugin):
         param = self._widget.boardInfoTreeView.currentIndex().sibling(row, 0).data()
         value = self._widget.boardInfoTreeView.currentIndex().sibling(row, 1).data()
 
-        board_param_list = ['board_id', 'imu_send_data_flag']
+        board_param_list = ['board_id', 'imu_send_data_flag', 'dynamixel_ttl_rs485_mixed']
         servo_param_list = ['pid_gain', 'profile_velocity', 'current_limit', 'send_data_flag']
 
         if value and (param in servo_param_list):
@@ -239,6 +240,14 @@ class BoardConfigurator(Plugin):
             servo_trq_msg.torque_enable = chr(0)
             self.servo_torque_pub_.publish(servo_trq_msg)
             rospy.sleep(0.5)
+        elif self._command == 'dynamixel_ttl_rs485_mixed':
+            try:
+                req.data.append(distutils.util.strtobool(self._widget.lineEdit.text()))
+            except ValueError as e:
+                print(e)
+                return
+            req.command = req.SET_DYNAMIXEL_TTL_RS485_MIXED
+
 
         rospy.loginfo('published message')
         rospy.loginfo('command: ' + str(req.command))

--- a/aerial_robot_nerve/spinal/srv/SetBoardConfig.srv
+++ b/aerial_robot_nerve/spinal/srv/SetBoardConfig.srv
@@ -17,6 +17,8 @@ uint8 SET_SERVO_CURRENT_LIMIT = 6
 # [slave_id, servo_index, current_limit] !torque disable!
 uint8 REBOOT = 7
 # [slave_id]
+uint8 SET_DYNAMIXEL_TTL_RS485_MIXED = 8
+# [slave_id, flag]
 
 uint8 command
 int32[] data


### PR DESCRIPTION
TTLとRS485の両方のdynamixelサーボモータを共存させたい場合のモードを作りました．
新たにboardinfoに`dynamixel_ttl_rs485_mixed`というパラメータを追加しました．
board_configuratorから変更が可能です．
spinalとneuronのファームウェアの更新が必要です．

尚、純hydrusのようにサーボモータが1つの場合、`dynamixel_ttl_rs485_mixed`はどちらでも問題ありません．