### PR TITLE
Increase the  max registration size for ros publisher/subscirber in spinal

### DIFF
--- a/aerial_robot_nerve/spinal/src/ros_lib/ros.h
+++ b/aerial_robot_nerve/spinal/src/ros_lib/ros.h
@@ -43,7 +43,7 @@
 namespace ros
 {
   /* be sure the max size of publisher and subscriber, as well as the size of message */
-  typedef NodeHandleStm_<STMF7Hardware, 20, 20, 255, 255> NodeHandle;
+  typedef NodeHandleStm_<STMF7Hardware, 50, 50, 255, 255> NodeHandle;
 }
 
 #endif


### PR DESCRIPTION
Right now the max registration size is 20 which is quite small. 
It is difficult to check the limitation. 
Right now this value is increased to 50, which is suitable for most of the cases.