### PR TITLE
Enable the accelerometer bias estimation for z axis

### DIFF
--- a/robots/hydrus/config/sensors/imu/spinal.yaml
+++ b/robots/hydrus/config/sensors/imu/spinal.yaml
@@ -5,6 +5,6 @@ sensor_plugin:
                 level_acc_noise_sigma: 0.05
                 z_acc_noise_sigma: 0.05 #real:0.05
                 level_acc_bias_noise_sigma: 0.001 #0.005#0.04  (> 0 means to do the acc bias estimation by kalman filter)
-                z_acc_bias_noise_sigma: 0 # (= 0 means not to do the acc bias estimation by kalman filter)
+                z_acc_bias_noise_sigma: 0.001 # (= 0 means not to do the acc bias estimation by kalman filter)
                 angle_bias_noise_sigma: 0.0002 #good for EKF
                 calib_time: 2.0


### PR DESCRIPTION
We think this is a better model for acceleration based kalman filter, especially for single axis.
And also had a better performance confirmed by test data.
