### PR TITLE
Add several parameters for outdoor flight

### DIFF
--- a/aerial_robot_base/include/aerial_robot_base/flight_navigation.h
+++ b/aerial_robot_base/include/aerial_robot_base/flight_navigation.h
@@ -4,6 +4,7 @@
 /* ros */
 #include <ros/ros.h>
 #include <aerial_robot_base/state_estimation.h>
+#include <aerial_robot_base/sensor/base_plugin.h>
 
 /* ros msg */
 #include <std_msgs/Int8.h>
@@ -297,6 +298,21 @@ protected:
       {
         ROS_ERROR("Flight Navigation: No correct sensor fusion for z(altitude), can not fly");
         return;
+      }
+
+    for(const auto& handler: estimator_->getGpsHandlers())
+      {
+        if(handler->getStatus() == Status::ACTIVE)
+          {
+            nhp_.param ("outdoor_takeoff_height", takeoff_height_, 1.2);
+            nhp_.param ("outdorr_convergent_duration", convergent_duration_, 0.5);
+            nhp_.param ("outdoor_xy_convergent_thresh", xy_convergent_thresh_, 0.6);
+            nhp_.param ("outdoor_alt_convergent_thresh", alt_convergent_thresh_, 0.05);
+
+            ROS_WARN_STREAM("update the navigation parameters for outdoor flight, takeoff height: " << takeoff_height_ << "; outdorr_convergent_duration: " << convergent_duration_ << "; outdoor_xy_convergent_thresh: " << xy_convergent_thresh_ << "; outdoor_alt_convergent_thresh: " << alt_convergent_thresh_);
+
+            break;
+          }
       }
 
     setNaviState(START_STATE);

--- a/aerial_robot_base/src/flight_navigation.cpp
+++ b/aerial_robot_base/src/flight_navigation.cpp
@@ -626,7 +626,7 @@ void Navigator::update()
 
         if(xy_control_mode_ == flight_nav::POS_CONTROL_MODE)
           {
-            if (fabs(delta.z() > alt_convergent_thresh_ || fabs(delta.x()) > xy_convergent_thresh_ || fabs(delta.y()) > xy_convergent_thresh_))
+            if (fabs(delta.z()) > alt_convergent_thresh_ || fabs(delta.x()) > xy_convergent_thresh_ || fabs(delta.y()) > xy_convergent_thresh_)
               convergent_start_time_ = ros::Time::now().toSec();
           }
         else

--- a/robots/hydrus/config/quad/TeleopNavigationConfig.yaml
+++ b/robots/hydrus/config/quad/TeleopNavigationConfig.yaml
@@ -2,13 +2,14 @@
 
 navigator:
         verbose: false
-        takeoff_height: 0.5
+        takeoff_height: 0.6
+        outdoor_takeoff_height: 1.5
 
         # teleop operation
         max_target_vel: 0.5
         joy_target_vel_interval: 0.005  # 0.2 / 20 = 0.01, 0.005 ~ 0.01  m/s
         joy_target_alt_interval: 0.02
-        max_target_yaw_rate: 0.1 #  0.05 
+        max_target_yaw_rate: 0.1 #  0.05
         cmd_vel_lev2_gain : 2.0
         nav_vel_limit : 0.3
 


### PR DESCRIPTION
1. add `outdoor_takeoff_height`, which is higher than the default height.
2. make hovering convergent thresholds less strict in outdoor environment,