### PR TITLE
Fix the bug about the sensor topic name from rosparam

### DIFF
--- a/aerial_robot_base/src/sensor/altitude.cpp
+++ b/aerial_robot_base/src/sensor/altitude.cpp
@@ -77,9 +77,7 @@ namespace sensor_plugin
 
       /* range sensor */
       std::string topic_name;
-      nhp_.param("range_sensor_sub_name", topic_name, string("/distance"));
-      if(estimator_->getAltHandlers().size() > 1)
-        indexed_nhp_.param("range_sensor_sub_name", topic_name, string("/distance" + std::to_string(index)));
+      getParam<std::string>("range_sensor_sub_name", topic_name, string("/distance"));
       range_sensor_sub_ = nh_.subscribe(topic_name, 10, &Alt::rangeCallback, this);
 
       if(estimator_->getGpsHandlers().size() == 1)

--- a/aerial_robot_base/src/sensor/gps.cpp
+++ b/aerial_robot_base/src/sensor/gps.cpp
@@ -94,11 +94,8 @@ namespace sensor_plugin
 
     /* ros subscriber for gps */
     std::string topic_name;
-    nhp_.param("gps_sub_name", topic_name, string("/gps"));
-    if(estimator_->getGpsHandlers().size() > 1)
-      indexed_nhp_.param("gps_sub_topic_name", topic_name, string("/gps" + std::to_string(index)));
+    getParam<std::string>("gps_sub_name", topic_name, string("/gps"));
     gps_sub_ = nh_.subscribe(topic_name, 5, &Gps::gpsCallback, this);
-
 
     if(estimator_->getGpsHandlers().size() == 1)
       {

--- a/aerial_robot_base/src/sensor/imu.cpp
+++ b/aerial_robot_base/src/sensor/imu.cpp
@@ -66,10 +66,7 @@ namespace sensor_plugin
       rosParamInit();
 
       std::string topic_name;
-
-      nhp_.param("imu_topic_name", topic_name, string("/imu"));
-      if(estimator_->getImuHandlers().size() > 1)
-        indexed_nhp_.param("imu_topic_name", topic_name, string("/imu") + std::to_string(index));
+      getParam<std::string>("imu_topic_name", topic_name, string("/imu"));
       imu_sub_ = nh_.subscribe<spinal::Imu>(topic_name, 10, &Imu::ImuCallback, this);
 
       nhp_.param("imu_pub_topic_name", topic_name, string("/uav/baselink/imu"));

--- a/aerial_robot_base/src/sensor/vo.cpp
+++ b/aerial_robot_base/src/sensor/vo.cpp
@@ -86,9 +86,7 @@ namespace sensor_plugin
 
     /* ros subscriber: vo */
     string topic_name;
-    nhp_.param("vo_sub_topic_name", topic_name, string("vo") );
-    if(estimator_->getVoHandlers().size() > 1)
-      indexed_nhp_.param("vo_sub_topic_name", topic_name, string("vo" + std::to_string(index)));
+    getParam<std::string>("vo_sub_topic_name", topic_name, string("/vo"));
 
     uint32_t queuse_size = 1; // if the timestamp is not synchronized, we can only use the latest sensor value.
     if(time_sync_) queuse_size = 10;


### PR DESCRIPTION
Enable the specific subscriber topic name for 1st sensor node (i.e., index = 1)