### PR TITLE
Fix the wrong option for shell script in travis

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -ex
 
 apt-get update -qq && apt-get install -y -q wget sudo lsb-release gnupg git sed # for docker
 echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
@@ -23,9 +23,9 @@ wstool init src
 wstool merge -t src src/aerial_robot/aerial_robot_${ROS_DISTRO}.rosinstall
 wstool update -t src
 rosdep install --from-paths src -y -q -r --ignore-src --rosdistro ${ROS_DISTRO} # -r is indisapensible
-env | grep ROS
-rosversion catkin
+
 # Build
-catkin build -p 1 -j 1
+catkin config --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+catkin build -p1 -j1 --no-status
 catkin run_tests -p1 -j1 --no-status aerial_robot --no-deps
 catkin_test_results --verbose build || catkin_test_results --all build


### PR DESCRIPTION
The important role of `set -e`:  https://heartbeats.jp/hbblog/2010/09/bash.html

Without this option, the following compile errors are ignored:
https://travis-ci.com/tongtybj/aerial_robot/jobs/246658453#L5745-L5756
```
Errors << spinal:make /home/travis/catkin_ws/logs/spinal/build.make.000.log    
5746/home/travis/catkin_ws/src/aerial_robot/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/flight_control/attitude/attitude_control.cpp: In member function 'void AttitudeController::setMotorNumber(uint8_t)':
5747/home/travis/catkin_ws/src/aerial_robot/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/flight_control/attitude/attitude_control.cpp:736:16: error: 'class ros::NodeHandle' has no member named 'logerror'
5748           nh_->logerror("ATTENTION: motor number is 0");
5749                ^
5750/home/travis/catkin_ws/src/aerial_robot/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/flight_control/attitude/attitude_control.cpp: In member function 'void AttitudeController::setUavModel(int8_t)':
5751/home/travis/catkin_ws/src/aerial_robot/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/flight_control/attitude/attitude_control.cpp:771:16: error: 'class ros::NodeHandle' has no member named 'logerror'
5752           nh_->logerror("ATTENTION: UAV model is not set");
5753                ^
5754make[2]: *** [CMakeFiles/spinal_flight_controller.dir/mcu_project/Jsk_Lib/flight_control/attitude/attitude_control.cpp.o] Error 1
5755make[1]: *** [CMakeFiles/spinal_flight_controller.dir/all] Error 2
5756make: *** [all] Error 2
```