### PR TITLE
Dragonの地磁気センサのpublish問題

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/state_estimate/attitude/attitude_estimate.h
+++ b/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/state_estimate/attitude/attitude_estimate.h
@@ -136,10 +136,7 @@ public:
             imu_msg_.acc_data[i] = estimator_->getAcc(Frame::BODY)[i];
 
             if(pub_smoothing_gyro_flag_)
-              {
                 imu_msg_.gyro_data[i] = estimator_->getSmoothAngular(Frame::BODY)[i];
-                imu_msg_.mag_data[i] = estimator_->getAngular(Frame::BODY)[i]; // for debug
-              }
             else
               imu_msg_.gyro_data[i] = estimator_->getAngular(Frame::BODY)[i];
  #if ESTIMATE_TYPE == COMPLEMENTARY

--- a/aerial_robot_nerve/spinal/mcu_project/Src/main.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/Src/main.cpp
@@ -250,8 +250,6 @@ int main(void){
   /* Extra Servo Control */
   extra_servo_.init(&htim3, &htim5, &nh_);
 
-  FlashMemory::read(); //IMU calib data, uav type
-
 #if NERVE_COMM
   /* NERVE */
   Spine::init(&hcan1, &nh_, &estimator_, GPIOE, GPIO_PIN_3);
@@ -272,8 +270,9 @@ int main(void){
   gps_.init(&huart3, &nh_);
 #endif
 
-
 #endif
+
+  FlashMemory::read(); //IMU calib data (including IMU in neurons)
 
   start_processing_flag_ = true;
   uint32_t now_time = HAL_GetTick();


### PR DESCRIPTION
初期の頃、自分で入れてたデバッグコードを消し忘れて、二日間躓いてしまった:

https://github.com/tongtybj/aerial_robot/compare/imu_bug?expand=1#diff-10cea19eec4d735bb801e3a6b27f88fcL141


また、main.cppの`FlashMemory::read()`はCANの初期化以降に実行しないと、neuronのIMUのキャリブデータが読み取れないことに気づいた。

そもそもだけど、neuronのIMUキャリブは個々のneuronで行うべきという考えもあるけど、どうだろう @chibi314 
そうなると、CANのpacketIDを増やさないといけないのと、16bitのIMUセンサ値をfloatにしないと行けないという余計な手間が出てくるが、これは今後の課題ということで。