### PR TITLE
Make the ADC scale in battery status configurable.

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/battery_status/battery_status.h
+++ b/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/battery_status/battery_status.h
@@ -13,6 +13,7 @@
 #define __BATTERY_STATUS_H
 
 #include "stm32f7xx_hal.h"
+#include "flashmemory/flashmemory.h"
 #include "adc.h"
 
 /* ros */
@@ -23,12 +24,12 @@
 #define VOLTAGE_CECK_INTERVAL 20 //500 //500ms
 #define ROS_PUB_INTERVAL 100 //20[ms]; 500[ms]
 /* https://www.sparkfun.com/datasheets/Sensors/DC%20Voltage%20and%20Current%20Sense%20PCB%20Spec%20Sheet.pdf */
-#define ADC_SCALE 12.65f * 0.001f // [mV/bit] for 12bit 3.3V ADC
 
 class BatteryStatus
 {
 public:
-  BatteryStatus():  voltage_status_pub_("/battery_voltage_status", &voltage_status_msg_)
+  BatteryStatus():  voltage_status_pub_("/battery_voltage_status", &voltage_status_msg_),
+                    adc_scale_sub_("/set_adc_scale", &BatteryStatus::adcScaleCallback, this)
   {
   }
 
@@ -39,11 +40,24 @@ public:
   {
     nh_ = nh;
     nh_->advertise(voltage_status_pub_);
+    nh_->subscribe<ros::Subscriber<std_msgs::Float32, BatteryStatus> >(adc_scale_sub_);
     hadc_ = hadc;
 
     voltage_ = -1;
+
+    FlashMemory::addValue(&adc_scale_, sizeof(float));
+
     HAL_ADC_Start(hadc_);
   }
+
+  void adcScaleCallback(const std_msgs::Float32& cmd_msg)
+  {
+    adc_scale_ = cmd_msg.data;
+    FlashMemory::erase();
+    FlashMemory::write();
+    nh_->loginfo("overwrite adc sacle");
+  }
+
   void update()
   {
     static uint32_t last_time = HAL_GetTick();
@@ -53,10 +67,10 @@ public:
       {
         last_time = HAL_GetTick();
         if(HAL_ADC_PollForConversion(hadc_,10) == HAL_OK)
-        	adc_value_ = HAL_ADC_GetValue(hadc_);
+          adc_value_ = HAL_ADC_GetValue(hadc_);
         HAL_ADC_Start(hadc_);
 
-        float voltage =  adc_value_ * ADC_SCALE;
+        float voltage =  adc_scale_ * adc_value_;
         if(voltage_ < 0) voltage_ = voltage;
 
         /* filtering */
@@ -65,14 +79,15 @@ public:
       }
 
     if(HAL_GetTick() - ros_pub_last_time > ROS_PUB_INTERVAL)
-		{
-			ros_pub_last_time = HAL_GetTick();
-			voltage_status_msg_.data = voltage_;
-			voltage_status_pub_.publish(&voltage_status_msg_);
-		}
+      {
+        ros_pub_last_time = HAL_GetTick();
+        voltage_status_msg_.data = voltage_;
+        voltage_status_pub_.publish(&voltage_status_msg_);
+      }
   }
 
   ros::Publisher voltage_status_pub_;
+  ros::Subscriber<std_msgs::Float32, BatteryStatus> adc_scale_sub_;
   std_msgs::Float32 voltage_status_msg_;
 
   inline float getVoltage() {return voltage_;}
@@ -82,6 +97,7 @@ private:
   ADC_HandleTypeDef *hadc_;
 
   float adc_value_;
+  float adc_scale_;
   float voltage_;
 };
 

--- a/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/extra_servo/extra_servo.h
+++ b/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/extra_servo/extra_servo.h
@@ -13,12 +13,12 @@
 #define __EXTRA_SERVO_H
 
 #include "stm32f7xx_hal.h"
+#include "flashmemory/flashmemory.h"
 #include "config.h"
 #include <ros.h>
 
 /* ros */
 #include <spinal/ServoControlCmd.h>
-#include <spinal/UavInfo.h>
 
 #define MAX_PWM  54000
 #define MAX_DUTY 20000.0f //conversion to [ms]


### PR DESCRIPTION
Given the error of the resistance value and reference voltage of ADC, it is better to introduce a configurable ADC scale which is stored in flash memory. 