### PR TITLE
Refactor several functions about teleop

### DIFF
--- a/aerial_robot_base/include/aerial_robot_base/flight_navigation.h
+++ b/aerial_robot_base/include/aerial_robot_base/flight_navigation.h
@@ -239,11 +239,6 @@ protected:
 
   double takeoff_height_;
 
-  double max_target_vel_;
-  double max_target_tilt_angle_;
-  double max_target_yaw_rate_;
-
-
   /* auto vel nav */
   bool vel_based_waypoint_;
   double nav_vel_limit_; // the vel limitation
@@ -251,26 +246,30 @@ protected:
   double vel_nav_gain_;
 
   /* teleop */
-  double joy_target_vel_interval_;
-  double joy_target_alt_interval_;
-
-  int navi_frame_int_;
-  uint8_t navi_frame_;
-
+  bool teleop_flag_;
   bool  vel_control_flag_;
   bool  pos_control_flag_;
   bool  xy_control_flag_;
   bool  alt_control_flag_;
   bool  yaw_control_flag_;
-
-  bool teleop_flag_;
   bool force_landing_flag_;
-
   bool check_joy_stick_heart_beat_;
   bool joy_stick_heart_beat_;
+
+  double joy_target_vel_interval_;
+  double joy_target_alt_interval_;
+  double max_target_vel_;
+  double max_target_tilt_angle_;
+  double max_target_yaw_rate_;
+
+  double joy_alt_deadzone_;
+  double joy_yaw_deadzone_;
+
   double joy_stick_prev_time_;
   double joy_stick_heart_beat_du_;
   double force_landing_to_halt_du_;
+
+  std::string teleop_local_frame_;
 
   /* battery info */
   double low_voltage_thre_;
@@ -331,11 +330,14 @@ protected:
     ROS_INFO("Start state");
   }
 
+  tf::Vector3 frameConversion(tf::Vector3 origin_val,  tf::Matrix3x3 r)
+  {
+    return r * origin_val;
+  }
+
   tf::Vector3 frameConversion(tf::Vector3 origin_val, float yaw)
   {
-    tf::Matrix3x3 orien;
-    orien.setRPY(0, 0, yaw);
-    return orien * origin_val;
+    return frameConversion(origin_val, tf::Matrix3x3(tf::createQuaternionFromYaw(yaw)));
   }
 
   void flightStatusAckCallback(const std_msgs::UInt8ConstPtr& ack_msg)

--- a/robots/hydrus/config/quad/TeleopNavigationConfig.yaml
+++ b/robots/hydrus/config/quad/TeleopNavigationConfig.yaml
@@ -10,6 +10,8 @@ navigator:
         joy_target_vel_interval: 0.005  # 0.2 / 20 = 0.01, 0.005 ~ 0.01  m/s
         joy_target_alt_interval: 0.02
         max_target_yaw_rate: 0.1 #  0.05
+        teleop_local_frame: fc
+
         cmd_vel_lev2_gain : 2.0
         nav_vel_limit : 0.3
 


### PR DESCRIPTION
- improve the yaw control by joystick 
  no more need to push the right joystick when you use the right joystick to control yaw angle (horizontal axis of right joystick)
- add reconfigurable argument: teleop_local_frame 
  provide better view for operator, for example, the camera frame like FPV.
 