### PR TITLE
increase the waiting time for the external magnetometer (Ublox) to start

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/sensors/imu/imu_mpu9250.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/Jsk_Lib/sensors/imu/imu_mpu9250.cpp
@@ -95,7 +95,7 @@ void IMUOnboard::magInit(void)
    * we need check the i2c connectio with external mag(HMC5883L) several times initially,
    * since the module UBlox M8N has some problem with the gps/mag simultaneous polling.
    */
-  HAL_Delay(500); // wait for the setup of the Blox M8N module
+  HAL_Delay(2000); // wait for the setup of the Blox M8N module
   uint8_t val[2];
   val[0] = HMC58X3_R_CONFB;
   val[1] = 0x20;


### PR DESCRIPTION
The start-up time of the magnetometer in ublox is longer in winter. 
So we have to increase the delay time to wait the startup.