### PR TITLE
Update the version of the dependent ros pakakges in .rosinstall

### DIFF
--- a/aerial_robot_kinetic.rosinstall
+++ b/aerial_robot_kinetic.rosinstall
@@ -8,7 +8,7 @@
 - git:
     local-name: sensor_interface
     uri: https://github.com/tongtybj/sensor_interface.git
-    version: aacc56a
+    version: 7f80e1b
 
 # motion capture(optitrack)
 - git:

--- a/aerial_robot_melodic.rosinstall
+++ b/aerial_robot_melodic.rosinstall
@@ -2,13 +2,13 @@
 - git:
     local-name: kalman_filter
     uri: https://github.com/tongtybj/kalman_filter.git
-    version: e140388
+    version: c550434
 
 # the sensor interface
 - git:
     local-name: sensor_interface
     uri: https://github.com/tongtybj/sensor_interface.git
-    version: aacc56a
+    version: 7f80e1b
 
 # motion capture(optitrack)
 - git:


### PR DESCRIPTION
https://github.com/tongtybj/sensor_interface/pull/8

Manifest.xml which is deprecated in catkin system will render the installation of `"python3-catkin-pkg`