### PR TITLE
Refine GPS waypoint navigation in final convergence phase

### DIFF
--- a/aerial_robot_base/src/flight_navigation.cpp
+++ b/aerial_robot_base/src/flight_navigation.cpp
@@ -768,7 +768,27 @@ void Navigator::update()
               }
             else
               {
-                ROS_WARN("back to pos nav control for way point");
+                if(gps_waypoint_)
+                  {
+                    tf::Vector3 gps_waypoint_delta;
+
+                    for (const auto& handler: estimator_->getGpsHandlers())
+                      {
+                        if(handler->getStatus() == Status::ACTIVE)
+                          {
+                            auto base_wp = boost::static_pointer_cast<sensor_plugin::Gps>(handler)->getCurrentPoint();
+                            gps_waypoint_delta = boost::static_pointer_cast<sensor_plugin::Gps>(handler)->getWolrdFrame() * sensor_plugin::Gps::wgs84ToNedLocalFrame(base_wp, target_wp_);
+                            break;
+                          }
+                      }
+                    ROS_WARN("back to pos nav control for GPS way point, gps waypoint delta: %f, %f", gps_waypoint_delta.x(), gps_waypoint_delta.y());
+                    gps_waypoint_  = false;
+                  }
+                else
+                  {
+                    ROS_WARN("back to pos nav control for way point");
+                  }
+
                 xy_control_mode_ = flight_nav::POS_CONTROL_MODE;
                 vel_based_waypoint_ = false;
                 setTargetVelX(0);


### PR DESCRIPTION
　GPS waypointモードが起動しているとき、1秒ごとに現在経緯度と目標経緯度との差をメートルに変換して、メートル単位での目標値が更新している。理論上では、メートル単位での目標地は一定のはずだが、GPSモジュールの受信誤差により、この目標地は常に変動する。
https://github.com/tongtybj/aerial_robot/blob/887e88a5f714075b3cdd4663222a6a4c69e6de34/aerial_robot_base/src/flight_navigation.cpp#L720-L732

　1秒ごとに起きる目標地の更新以外のときは、固定の目標値に向かってナビゲーションをする。　差が`vel_nav_threshold`以上の場合は速度制御モードで、以下の場合は位置制御モードになる。しかし、GPS waypoint時は目標値が変動するため、位置制御モードに入ったあとにも、位置の差が開いて、もう一度速度制御モードになる。

　この繰り返しによって、機体の制御が発散することがある。よって、目標値との差が一度でも`vel_nav_threshold`以下になったら、GPS waypointによる目標値の更新は止めるようにする。
~~これは、目標経緯度との差がメートル単位の`vel_nav_threshold`以上であることを許容することになるが、そこまでずれることはない。~~ `vel_nav_threshold`自体の値も大きくないので、GPS waypointの更新の精度はあまり落ちない。

　また、制御が発散には、`vel_nav_gain_`も関係している: https://github.com/tongtybj/aerial_robot/blob/887e88a5f714075b3cdd4663222a6a4c69e6de34/aerial_robot_base/src/flight_navigation.cpp#L761
 つまり、速度制御モード下で、目標地との位置の差を目標速度に変換するときに、このゲインが大き過ぎると、過度の移動速度が発生して、加えて、目標地が頻繁に変動すると、機体の制御は発散する。