### PR TITLE
Fix bug: block gps waypoint when doing force attitude control

### DIFF
--- a/aerial_robot_base/src/flight_navigation.cpp
+++ b/aerial_robot_base/src/flight_navigation.cpp
@@ -715,6 +715,8 @@ void Navigator::update()
       }
     case HOVER_STATE:
       {
+        if(force_att_control_flag_) break;
+
         if(gps_waypoint_)
           {
             if(ros::Time::now().toSec() - gps_waypoint_time_ > gps_waypoint_check_du_)


### PR DESCRIPTION
GPS waypointを行っている最中に, コントローラから`force_att_control_flag_`を送っても、ジョイスティックで思うように操縦できないというバグがあり、rosbagをみたら、勝手にvel_control_modeに切り替わってしまったことが変わった。

原因は、このPRで追加した部分で、`gps_waypoint_`が`true`の場合は、また勝手にwaypointへと進んでしまうという現象が起きており、そこでジョイスティックを倒すと、手動操縦の目標速度+ waypointへの目標速度の和が制御器に渡され、機体が暴走する。

なので、`force_att_control_flag_`が`true`時はgps waypoint制御を無視するようにした。