### PR TITLE
Reduce the publish rate of joy stick 

### DIFF
--- a/aerial_robot_base/launch/external_module/joy_stick.launch
+++ b/aerial_robot_base/launch/external_module/joy_stick.launch
@@ -4,5 +4,6 @@
   <node pkg="joy" type="joy_node" name="joy_node"  output="screen" > 
 
     <param name="dev" type="string" value="/dev/input/js0"/>
+    <param name="coalesce_interval" value="0.025"/>
   </node>
 </launch>


### PR DESCRIPTION
In order to relax the bandwidth between local pc and robot.
Reduce the publish rate of joy stick from 200Hz to 40Hz.
