### PR TITLE
[Fix Bug] the naive assignment of the rotor direciton from the KDL model 

### DIFF
--- a/aerial_robot_model/src/transformable_aerial_robot_model/kinematics.cpp
+++ b/aerial_robot_model/src/transformable_aerial_robot_model/kinematics.cpp
@@ -289,8 +289,12 @@ namespace aerial_robot_model {
     if(current_seg.getJoint().getName().find("rotor") != std::string::npos)
       {
         /* add the rotor direction */
-        if(verbose_) ROS_WARN("%s, rototation is %f", current_seg.getJoint().getName().c_str(), current_seg.getJoint().JointAxis().z());
-        rotor_direction_.insert(std::make_pair(std::atoi(current_seg.getJoint().getName().substr(5).c_str()), current_seg.getJoint().JointAxis().z()));
+        auto urdf_joint =  model_.getJoint(current_seg.getJoint().getName());
+        if(urdf_joint->type == urdf::Joint::CONTINUOUS)
+          {
+            if(verbose_) ROS_WARN("joint name: %s, z axis: %f", current_seg.getJoint().getName().c_str(), urdf_joint->axis.z);
+            rotor_direction_.insert(std::make_pair(std::atoi(current_seg.getJoint().getName().substr(5).c_str()), urdf_joint->axis.z));
+          }
       }
 
     /* recursion process for children segment */


### PR DESCRIPTION
The joint axis in KDL Joint model has combined the '<origin>' and '<axis>' information in urdf files. 
Therefore, 
https://github.com/tongtybj/aerial_robot/compare/rotor_direction?expand=1#diff-a15de1b9cbd204ffb95d10e93ac4006bL293
might cause the rotor direction to be zero, since it is a float value smaller than 1. 
The refined extraction way can solve this problem since it directly access to the URDF joint model.

So far, this naive assignment only causes the bug in case of  Hydrus with fixed tilt propeller (e.g., mbzirc hydrus).
