### PR TITLE
Automatically stop motors by checking the  impact  from the  ground in force landing phase.

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
+++ b/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
@@ -281,6 +281,7 @@ namespace aerial_robot_navigation
     double joy_stick_prev_time_;
     double joy_stick_heart_beat_du_;
     double force_landing_to_halt_du_;
+    bool force_landing_auto_stop_flag_;
 
     std::string teleop_local_frame_;
 

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -637,6 +637,17 @@ void BaseNavigator::update()
 
   tf::Vector3 delta = target_pos_ - estimator_->getPos(Frame::COG, estimate_mode_);
 
+  /* check the hard landing in force_landing model */
+  if(force_landing_flag_)
+    {
+      if(!estimator_->getLandingMode()) estimator_->setLandingMode(true);
+      if(estimator_->getLandedFlag() && force_landing_auto_stop_flag_)
+        {
+          ROS_WARN("hard touch to the ground in force landing mode, disarm motor");
+          setNaviState(STOP_STATE);
+        }
+    }
+
   switch(getNaviState())
     {
     case START_STATE:
@@ -856,6 +867,7 @@ void BaseNavigator::rosParamInit()
   getParam<double>(nh, "joy_yaw_deadzone", joy_yaw_deadzone_, 0.2);
   getParam<double>(nh, "joy_stick_heart_beat_du", joy_stick_heart_beat_du_, 2.0);
   getParam<double>(nh, "force_landing_to_halt_du", force_landing_to_halt_du_, 1.0);
+  getParam<bool>(nh, "force_landing_auto_stop_flag", force_landing_auto_stop_flag_, true);
   getParam<bool>(nh, "joy_udp", joy_udp_, true);
   getParam<bool>(nh, "check_joy_stick_heart_beat", check_joy_stick_heart_beat_, false);
   getParam<std::string>(nh, "teleop_local_frame", teleop_local_frame_, std::string("root"));

--- a/robots/dragon/config/quad/NavigationConfig.yaml
+++ b/robots/dragon/config/quad/NavigationConfig.yaml
@@ -24,5 +24,8 @@ navigation:
   gps_waypoint_threshold: 3.0
   gps_waypoint_check_du: 1.0
 
+  # force landing
+  force_landing_auto_stop_flag: false
+
   # desire tilt
   baselink_rot_pub_interval: 0.2


### PR DESCRIPTION
Check the  acceleration on z axis in force landing phase, and if the positive (i.e., upward) impact is observed, we consider the robot touches to the ground, and thus stop motor. 

`force_landing_auto_stop_flag` is the rosparameter to enable / disable this function. 