### PR TITLE
Refine the script to calculate the tracking error RMS from rostopic

### DIFF
--- a/aerial_robot_base/scripts/rms.py
+++ b/aerial_robot_base/scripts/rms.py
@@ -4,7 +4,7 @@ import rospy
 from std_msgs.msg import Empty
 from std_msgs.msg import Int8
 from std_msgs.msg import UInt16
-from aerial_robot_msgs.msg import FlatnessPid, States
+from aerial_robot_msgs.msg import PoseControlPid
 
 import sys, select, termios, tty, math
 
@@ -14,35 +14,23 @@ s: start to subscribe the topic regarding to control errors, and start to calcul
 h: stop the calculate the output the RMS results.
 """
 
-def pos_err_callback(data):
+def cb(data):
         global start_flag
         if start_flag == True:
-                global four_axis_cnt
-                global four_axis_squared_errors_sum
-                four_axis_cnt = four_axis_cnt + 1
+                global pose_cnt
+                global pose_squared_errors_sum
+                pose_cnt = pose_cnt + 1
 
-                four_axis_squared_errors_sum[0] = four_axis_squared_errors_sum[0] + data.pitch.pos_err * data.pitch.pos_err
-                four_axis_squared_errors_sum[1] = four_axis_squared_errors_sum[1] + data.roll.pos_err * data.roll.pos_err
-                four_axis_squared_errors_sum[2] = four_axis_squared_errors_sum[2] + data.throttle.pos_err * data.throttle.pos_err
-                four_axis_squared_errors_sum[3] = four_axis_squared_errors_sum[3] + data.yaw.pos_err * data.yaw.pos_err
+                pose_squared_errors_sum[0] = pose_squared_errors_sum[0] + data.x.err_p * data.x.err_p
+                pose_squared_errors_sum[1] = pose_squared_errors_sum[1] + data.y.err_p * data.y.err_p
+                pose_squared_errors_sum[2] = pose_squared_errors_sum[2] + data.z.err_p * data.z.err_p
 
-                temp_rms = [math.sqrt(i / four_axis_cnt) for i in four_axis_squared_errors_sum]
-                rospy.logdebug("RMS errors of position: [%f, %f, %f], RMS error of yaw: %f", temp_rms[0], temp_rms[1], temp_rms[2], temp_rms[3])
+                pose_squared_errors_sum[3] = pose_squared_errors_sum[3] + data.roll.err_p * data.roll.err_p
+                pose_squared_errors_sum[4] = pose_squared_errors_sum[4] + data.pitch.err_p * data.pitch.err_p
+                pose_squared_errors_sum[5] = pose_squared_errors_sum[5] + data.yaw.err_p * data.yaw.err_p
 
-def att_err_callback(data):
-        global start_flag
-        if start_flag == True:
-                global att_cnt
-                global roll_pitch_squared_errors_sum
-
-                att_cnt = att_cnt + 1
-
-                roll_pitch_squared_errors_sum = [prev_sum + data.states[6 + i].state[2].x**2 for i, prev_sum in enumerate(roll_pitch_squared_errors_sum)]
-                #att_pitch_sum = att_pitch_sum + data.states[7].state[2].x * data.states[7].state[2].x
-
-                temp_rms = [math.sqrt(i / att_cnt) for i in roll_pitch_squared_errors_sum ]
-                #pitch_rms = math.sqrt(att_pitch_sum / att_cnt)
-                rospy.logdebug("RMS errors of roll and pitch: [%f, %f] \n", temp_rms[0], temp_rms[1])
+                rms = [math.sqrt(i / pose_cnt) for i in pose_squared_errors_sum]
+                #rospy.loginfo("RMS errors of pos: [%f, %f, %f]; rot: [%f, %f, %f]", rms[0], rms[1], rms[2], rms[3], rms[4], rms[5])
 
 def getKey():
         tty.setraw(sys.stdin.fileno())
@@ -57,14 +45,10 @@ if __name__=="__main__":
         start_flag = False
         msg_cnt = 0
 
-        four_axis_squared_errors_sum = [0] * 4
-        roll_pitch_squared_errors_sum = [0] * 2
+        pose_squared_errors_sum = [0] * 6
+        pose_cnt = 0
 
-        att_cnt = 0
-        four_axis_cnt = 0
-
-        rospy.Subscriber("/controller/debug", FlatnessPid, pos_err_callback)
-        rospy.Subscriber("/uav/full_state", States, att_err_callback)
+        rospy.Subscriber("debug/pose/pid", PoseControlPid, cb)
 
         rospy.init_node('rms_error')
 
@@ -79,22 +63,16 @@ if __name__=="__main__":
                         if key == 'h':
                                 rospy.loginfo("stop calculation")
 
-                                temp_rms = [0] * 2
-                                temp2_rms = [0] * 4
-                                if att_cnt > 0:
-                                        temp_rms = [math.sqrt(i / att_cnt) for i in roll_pitch_squared_errors_sum ]
-                                if four_axis_cnt > 0:
-                                        temp2_rms = [math.sqrt(i / four_axis_cnt) for i in four_axis_squared_errors_sum]
+                                rms = [0] * 6
+                                if pose_cnt > 0:
+                                        rms = [math.sqrt(i / pose_cnt) for i in pose_squared_errors_sum]
 
-
-                                rospy.loginfo("RMS of att errors: [%f, %f, %f], pos errors: [%f, %f, %f]", temp_rms[0], temp_rms[1], temp2_rms[3], temp2_rms[0], temp2_rms[1], temp2_rms[2])
+                                rospy.loginfo("RMS of pos errors: [%f, %f, %f], att errors: [%f, %f, %f]", rms[0], rms[1], rms[2], rms[3], rms[4], rms[5])
 
                                 start_flag = False
-                                att_cnt = 0
-                                four_axis_cnt = 0
 
-                                four_axis_squared_errors_sum = [0] * 4
-                                roll_pitch_squared_errors_sum = [0] * 2
+                                pose_cnt = 0
+                                pose_squared_errors_sum = [0] * 6
 
                         else:
                                 if (key == '\x03'):


### PR DESCRIPTION
Useful for the evaluation of experiment when writing paper.

Usage with rosbag:

```
$ rosbag play xxx.bag -s xx -u xx --pause
```
**note**: please refer to http://wiki.ros.org/rosbag/Commandline#play for the above options 

```
$ rosrun aerial_robot_base rms.py __ns:=$(robot_ns)
```
**note1**: `$(robot_ns)` is the namespace of robot (e.g., `hydrus`, `hydrus_xi`, `dragon`, etc.)
**note2**:  `s` to start the calculation (also please start rosbag play ), and `h` to stop the calculation and the RMS is dumped in the console (i.e., `RMS of pos errors: [0.000000, 0.000000, 0.000000], att errors: [0.000000, 0.000000, 0.000000]`)



