### PR TITLE
Refine the termination process of spinal rosserial

### DIFF
--- a/aerial_robot_nerve/spinal_ros_bridge/include/spinal_ros_bridge/session.h
+++ b/aerial_robot_nerve/spinal_ros_bridge/include/spinal_ros_bridge/session.h
@@ -157,11 +157,12 @@ private:
   // TODO: Total message timeout, implement primarily in ReadBuffer.
   void read_sync_header() {
     // Stop the tx from MCU, not sure whether the process should be here
-    if(terminate_start_flag_ )
+    if(terminate_start_flag_)
       {
+        terminate_start_flag_ = false;
         std::vector<uint8_t> message(0);
         write_message(message, rosserial_msgs::TopicInfo::ID_TX_STOP, client_version);
-        ROS_WARN("stop rosserial communication \n");
+        ROS_WARN("stop rosserial communication");
         ros::shutdown();
         return;
       }
@@ -410,6 +411,15 @@ private:
     if (error == boost::asio::error::operation_aborted) {
       return;
     }
+
+    if(terminate_start_flag_)
+      {
+        terminate_start_flag_ = false;
+        ROS_WARN("stop rosserial communication");
+        ros::shutdown();
+        return;
+      }
+
     ROS_WARN("Sync with device lost.");
     attempt_sync();
   }

--- a/aerial_robot_nerve/spinal_ros_bridge/src/serial_node.cpp
+++ b/aerial_robot_nerve/spinal_ros_bridge/src/serial_node.cpp
@@ -48,10 +48,11 @@ int main(int argc, char* argv[])
   int baud;
   ros::param::param<int>("~baud", baud, 57600);
 
+  sleep(1.0);
+
   // Run boost::asio io service in a background thread.
   boost::asio::io_service io_service;
   new rosserial_server::SerialSession(io_service, port, baud);
-  ros::Duration(1.0).sleep();
   boost::thread(boost::bind(&boost::asio::io_service::run, &io_service));
 
   ros::MultiThreadedSpinner spinner(2);


### PR DESCRIPTION
Solve the problem that the rosserial process could not be stopped by `Ctrl-c` once ` Sync with device lost.`