### PR TITLE
Revert the wrong modification by #422, related to rosserial

### DIFF
--- a/aerial_robot_nerve/spinal_ros_bridge/src/serial_node.cpp
+++ b/aerial_robot_nerve/spinal_ros_bridge/src/serial_node.cpp
@@ -48,11 +48,10 @@ int main(int argc, char* argv[])
   int baud;
   ros::param::param<int>("~baud", baud, 57600);
 
-  sleep(1.0);
-
   // Run boost::asio io service in a background thread.
   boost::asio::io_service io_service;
   new rosserial_server::SerialSession(io_service, port, baud);
+  ros::Duration(1.0).sleep();
   boost::thread(boost::bind(&boost::asio::io_service::run, &io_service));
 
   ros::MultiThreadedSpinner spinner(2);


### PR DESCRIPTION
I forgot it is important to add a sleep after `new rosserial_server::SerialSession(io_service, port, baud);` .
