### PR TITLE
Abolish the yaw I term clamp process when the total value is saturated.

### DIFF
--- a/robots/hydrus/src/hydrus_lqi_controller.cpp
+++ b/robots/hydrus/src/hydrus_lqi_controller.cpp
@@ -140,7 +140,6 @@ void HydrusLQIController::allocateYawTerm()
   double residual = max_term - pid_controllers_.at(YAW).getLimitSum();
   if(residual > 0)
     {
-      pid_controllers_.at(YAW).setErrI(pid_controllers_.at(YAW).getErrI() - residual / yaw_gains_.at(index)[1]);
       target_thrust_yaw_term *= (1 - residual / max_term);
     }
 


### PR DESCRIPTION
The removed line, which  clamps the I term in saturation case (i.e., P_term + I_term > limit) ,  cannot recover the saturation due to the  sudden grow of P term.