### PR TITLE
[Dragon] update the rotor and link configuration 

### DIFF
--- a/robots/dragon/config/MotorInfo.yaml
+++ b/robots/dragon/config/MotorInfo.yaml
@@ -1,42 +1,58 @@
 motor_info:
-        min_pwm: 0.60 # = 1200 [ms]
-        max_pwm: 0.86 # = 1720 [ms]
+        min_pwm: 0.55 # = 1100 [ms]
+        max_pwm: 0.92 # = 1840 [ms]
         min_thrust: 0 # [N]
-        force_landing_thrust: 12 #[N]
+        force_landing_thrust: 13 #[N]
         pwm_conversion_mode: 1 # Polynominal Mode
         vel_ref_num: 4
         ref1:        
                 voltage: 25.2
-                max_thrust: 18.04 # N 
-                polynominal4: -5.7063259 # x 10^4
-                polynominal3: 15.577885 # x10^3
-                polynominal2: -8.8434316 # x10^2
-                polynominal1: 13.882688 # x10
-                polynominal0: 58.697129 # x1
+                max_thrust: 21.1 # N < max is 21.20V (60.5 A), but currency max of ESC is 60 A,
+                polynominal4: 3.0281784 # x 10^4, 7 decimal places (total 8 decimal places)
+                polynominal3: -12.648033 # x10^3, 6 decimal places (total 8 decimal places)
+                polynominal2: 12.444642 # x10^2,  6 decimal places (total 8 decimal places)
+                polynominal1: 19.748675 # x10,    6 decimal places (total 8 decimal places)
+                polynominal0: 51.760116 # x1,     6 decimal places (total 8 decimal places)
         ref2:
                 voltage: 24.2
-                max_thrust: 16.27 # N
-                polynominal4: -8.9762987 # x 10^4
-                polynominal3: 25.174311 # x10^3
-                polynominal2: -18.136790 # x10^2
-                polynominal1: 18.573183 # x10
-                polynominal0: 58.265334 # x1
+                max_thrust: 20.7 # N
+                polynominal4: 2.7596285 # x 10^4
+                polynominal3: -10.559170 # x10^3
+                polynominal2: 7.4549071 # x10^2
+                polynominal1: 24.831527 # x10
+                polynominal0: 51.051452 # x1
         ref3:        
                 voltage: 23.2
-                max_thrust: 15.25 # N
-                polynominal4: -9.9940524 # x 10^4
-                polynominal3: 25.287343 # x10^3
-                polynominal2: -14.915788 # x10^2
-                polynominal1: 17.404827 # x10
-                polynominal0: 58.512989 # x1
+                max_thrust: 20.0 # N
+                polynominal4: 3.2305734 # x 10^4
+                polynominal3: -12.136797 # x10^3
+                polynominal2: 8.7958137 # x10^2
+                polynominal1: 25.485516 # x10
+                polynominal0: 51.383410 # x1
         ref4:
                 voltage: 22.2
-                max_thrust: 14.22 # N
-                polynominal4: -14.725489 # x 10^4
-                polynominal3: 35.482073 # x10^3
-                polynominal2: -21.115724 # x10^2
-                polynominal1: 19.991898 # x10
-                polynominal0: 58.454254 # x1
+                max_thrust: 18.7 # N
+                polynominal4: 5.4992734 # x 10^4
+                polynominal3: -20.212052 # x10^3
+                polynominal2: 17.654243 # x10^2
+                polynominal1: 23.203110 # x10
+                polynominal0: 52.027534 # x1
+        ref5:
+                voltage: 21.2
+                max_thrust: 17.4 # N
+                polynominal4: 5.3509568 # x 10^4
+                polynominal3: -17.044938 # x10^3
+                polynominal2: 9.1921159 # x10^2
+                polynominal1: 31.009709 # x10
+                polynominal0: 51.145790 # x1
+        ref6:
+                voltage: 20.2
+                max_thrust: 16.1 # N
+                polynominal4: 11.365290 # x 10^4
+                polynominal3: -37.617704 # x10^3
+                polynominal2: 32.055642 # x10^2
+                polynominal1: 23.049673 # x10
+                polynominal0: 52.481646 # x1
 
 
         # for simualtion

--- a/robots/dragon/test/dragon_control.test
+++ b/robots/dragon/test/dragon_control.test
@@ -49,7 +49,7 @@
           reset: "rosrun dragon transformation_demo.py _mode:=0 _reset:=1"
           reset_duration: 10
     </rosparam>
-    <param name="init_form_duration" value="25.0" />
+    <param name="init_form_duration" value="30.0" />
     <param name="init_angle_threshold" value="0.04" />
   </test>
 
@@ -83,7 +83,7 @@
              reset_duration: 0
           -->
     </rosparam>
-    <param name="init_form_duration" value="25.0" />
+    <param name="init_form_duration" value="30.0" />
     <param name="init_angle_threshold" value="0.04" />
   </test>
 

--- a/robots/dragon/urdf/dragon_link.urdf.xacro
+++ b/robots/dragon/urdf/dragon_link.urdf.xacro
@@ -99,10 +99,10 @@
 
     <link name="gimbal${self}_roll_module">
       <inertial>
-        <origin xyz="${gimbal_roll_x_offset - 17.67 * 0.001} ${0.42 * 0.001} ${15.23 * 0.001}" rpy="0 0 0"/>
-        <mass value="0.4578" />
+        <origin xyz="${gimbal_roll_x_offset - 17.60 * 0.001} ${0.42 * 0.001} ${15.48 * 0.001}" rpy="0 0 0"/>
+        <mass value="0.4604" />
         <inertia
-            ixx="0.0004" iyy="0.0005" izz="0.0003"
+            ixx="0.0004" iyy="0.0004" izz="0.0003"
             ixy="0" ixz="-0.0003" iyz="0"/>
       </inertial>
       <visual>
@@ -142,10 +142,10 @@
 
     <link name="gimbal${self}_pitch_module">
       <inertial>
-        <origin xyz="0 ${0.46 * 0.001}  ${-7.3 * 0.001}" rpy="0 0 0"/>
-        <mass value="0.4235" />
+        <origin xyz="0 ${0.33 * 0.001}  ${-8.71 * 0.001}" rpy="0 0 0"/>
+        <mass value="0.5301" />
         <inertia
-            ixx="0.0048" iyy="0.0002" izz="0.0048"
+            ixx="0.0061" iyy="0.0001" izz="0.0061"
             ixy="0.0" ixz="0.0" iyz="0.0"/>
       </inertial>
       <visual>

--- a/robots/dragon/urdf/dragon_link.urdf.xacro
+++ b/robots/dragon/urdf/dragon_link.urdf.xacro
@@ -10,11 +10,18 @@
       <!-- head -->
       <xacro:if value="${self == 1}">
         <inertial>
+          <origin xyz="${link_length* 0.5 + 15.09 * 0.001} ${-6.67 * 0.001} ${-27.21 * 0.001}" rpy="0 0 0"/>
+          <mass value="0.7968" />
+          <inertia
+              ixx="0.00095" iyy="0.0151" izz="0.0148"
+              ixy="-0.00098" ixz="0.0003" iyz="0.0001"/>
+          <!--
           <origin xyz="${link_length* 0.5 + 18.25 * 0.001} ${-7.17 * 0.001} ${-25.73 * 0.001}" rpy="0 0 0"/>
           <mass value="0.7408" />
           <inertia
               ixx="0.00095" iyy="0.0143" izz="0.0139"
               ixy="-0.00099" ixz="0.0003" iyz="0.0001"/>
+          -->
         </inertial>
         <xacro:link_model type="head_link" />
       </xacro:if>
@@ -23,11 +30,18 @@
         <!-- tail -->
         <xacro:if value="${self == child}">
           <inertial>
+            <origin xyz="${link_length* 0.5 - 44.26 * 0.001} ${-0.11 * 0.001} ${-20.72 * 0.001}" rpy="0 0 0"/>
+            <mass value="0.7943" />
+            <inertia
+                ixx="0.0012" iyy="0.0145" izz="0.0134"
+                ixy="0.0" ixz="0.0003" iyz="0.0000"/>
+            <!--
             <origin xyz="${link_length* 0.5 - 45.44 * 0.001} ${-0.12 * 0.001} ${-18.74 * 0.001}" rpy="0 0 0"/>
             <mass value="0.7383" />
             <inertia
                 ixx="0.0012" iyy="0.0137" izz="0.0126"
                 ixy="0.0" ixz="0.0002" iyz="0.0"/>
+            -->
           </inertial>
           <xacro:link_model type="end_link" />
         </xacro:if>
@@ -35,22 +49,36 @@
           <!-- baselink -->
           <xacro:if value="${baselink}">
             <inertial>
+              <origin xyz="${link_length* 0.5 + 9.54 * 0.001} ${-4.74 * 0.001} ${-15.68 * 0.001}" rpy="0 0 0"/>
+              <mass value="1.1348" />
+              <inertia
+                  ixx="0.0018" iyy="0.0228" izz="0.0219"
+                  ixy="-0.0009" ixz="-0.0006" iyz="0.0001"/>
+              <!--
               <origin xyz="${link_length* 0.5 + 11.92 * 0.001} ${-4.98 * 0.001} ${-14.07 * 0.001}" rpy="0 0 0"/>
               <mass value="1.07879" />
               <inertia
                   ixx="0.0018" iyy="0.0219" izz="0.0211"
                   ixy="-0.001" ixz="-0.0007" iyz="0.0001"/>
+              -->
             </inertial>
             <xacro:link_model type="baselink" />
           </xacro:if>
           <!-- general -->
           <xacro:unless value="${baselink}">
             <inertial>
+              <origin xyz="${link_length* 0.5 - 12.78 * 0.001} ${-5.80 * 0.001} ${-16.95 * 0.001}" rpy="0 0 0"/>
+              <mass value="0.9289" />
+              <inertia
+                  ixx="0.0015" iyy="0.0198" izz="0.0189"
+                  ixy="-0.0008" ixz="-0.0001" iyz="0.0001"/>
+              <!--
               <origin xyz="${link_length* 0.5 - 11.75 * 0.001} ${-6.17 * 0.001} ${-15.04 * 0.001}" rpy="0 0 0"/>
               <mass value="0.8729" />
               <inertia
                   ixx="0.0015" iyy="0.0189" izz="0.0181"
                   ixy="-0.0008" ixz="-0.0002" iyz="0.0001"/>
+              -->
             </inertial>
             <xacro:link_model type="general_link" />
           </xacro:unless>
@@ -139,7 +167,7 @@
 
     <link name="thrust${self}">
       <inertial>
-        <origin xyz="0 0 0.1" rpy="0 0 0"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
         <mass value="0.0001"/>
         <inertia
             ixx="0.00001" ixy="0.0" ixz="0.0"


### PR DESCRIPTION
## What is this 

New link and rotor configuration for Dragon

### 1. Link
Change battery for better flight performance:
[Turnigy 1300mAh 6S 35C Lipo](https://hobbyking.com/en_us/turnigy-1300mah-6s-35c-lipo-pack-450-helicopter-hk-trex-rave-e4-etc.html?queryID=&objectID=18141&indexName=hbk_live_products_analytics) => [Turnigy Bolt 1300mAh 6S 22.8V 65~130C LiHV](https://hobbyking.com/en_us/turnigy-bolt-1300mah-6s-22-8v-65-130c-high-voltage-lipoly-pack-lihv.html?queryID=&objectID=47548&indexName=hbk_live_products_analytics)

### 2. Rotor 
 Please check this [website](https://www.rc-castle.com/index.php?route=product/product&product_id=8890&search=counter)
- propeller:  12 blades with  70mm duct
- rotor: freewing  2952 2100Kv Inrunner Brushless Motor
- ESC: [T-motor  60A](https://store.tmotor.com/goods.php?id=375)

## Why 
- Lipo battery had a worse flight performace because of the significant voltage drop.
- The old type (6blade, 2200Kv outrunner) is out of stock. 
- This new type has better efficiency and less vibration due to the inrunner rotor.


## TODO
- [x] check the total mass with the real robot.