### PR TITLE
Correct the python scripts for rqt gui to be compatible in ros noetic

### DIFF
--- a/aerial_robot_nerve/spinal/src/spinal/board_configurator.py
+++ b/aerial_robot_nerve/spinal/src/spinal/board_configurator.py
@@ -212,7 +212,7 @@ class BoardConfigurator(Plugin):
         elif self._command == 'pid_gain':
             try:
                 req.data.append(int(self._servo_index))
-                pid_gains = map(lambda x: int(x), self._widget.lineEdit.text().split(','))
+                pid_gains = list(map(lambda x: int(x), self._widget.lineEdit.text().split(',')))
                 if len(pid_gains) != 3:
                     raise ValueError('Input 3 gains(int)')
                 req.data.extend(pid_gains)
@@ -268,7 +268,7 @@ class BoardConfigurator(Plugin):
         elif self._command == 'resolution[joint:servo]':
             try:
                 req.data.append(int(self._servo_index))
-                resolutions = map(lambda x: int(x), self._widget.lineEdit.text().split(':'))
+                resolutions = list(map(lambda x: int(x), self._widget.lineEdit.text().split(':')))
                 if len(resolutions) != 2:
                     raise ValueError('Input 2 resoultion(int)')
                 req.data.extend(resolutions)

--- a/aerial_robot_nerve/spinal/src/spinal/servo_monitor.py
+++ b/aerial_robot_nerve/spinal/src/spinal/servo_monitor.py
@@ -16,6 +16,9 @@ import rosgraph
 from functools import partial
 from operator import add
 import xml.etree.ElementTree as ET
+import sys
+
+PYTHON_VERSION = sys.version_info[0]
 
 
 class ServoMonitor(Plugin):
@@ -136,8 +139,8 @@ class ServoMonitor(Plugin):
             rospy.logerr("No servo exists")
             return
         msg = ServoTorqueCmd()
-        msg.index = chr(servo_index)
-        msg.torque_enable = chr(enable)
+        msg.index = [servo_index]
+        msg.torque_enable = [enable]
         self.servo_torque_pub_.publish(msg)
 
     def servoOn(self):
@@ -152,8 +155,8 @@ class ServoMonitor(Plugin):
             rospy.logerr("No servo exists")
             return
         msg = ServoTorqueCmd()
-        msg.index = reduce(add, [chr(i) for i in range(servo_num)])
-        msg.torque_enable = reduce(add, [chr(enable)] * servo_num)
+        msg.index = list(range(servo_num))
+        msg.torque_enable = [enable] * servo_num
         self.servo_torque_pub_.publish(msg)
 
     def allServoOnButtonCallback(self):
@@ -181,8 +184,8 @@ class ServoMonitor(Plugin):
 
         #need to disable servo torque
         servo_trq_msg = ServoTorqueCmd()
-        servo_trq_msg.index = chr(servo_index)
-        servo_trq_msg.torque_enable = chr(0)
+        servo_trq_msg.index = [servo_index]
+        servo_trq_msg.torque_enable = [0]
         self.servo_torque_pub_.publish(servo_trq_msg)
         rospy.sleep(0.5)
 
@@ -245,7 +248,9 @@ class ServoMonitor(Plugin):
 
     def servoTorqueStatesCallback(self, msg):
         for i, s in enumerate(msg.torque_enable):
-            self._table_data[i][self._headers.index("torque")] = "on" if bool(ord(s)) else "off"
+            if PYTHON_VERSION == 2:
+                s = ord(s)
+            self._table_data[i][self._headers.index("torque")] = "on" if bool(s) else "off"
 
     def update(self):
         if not self._table_data:


### PR DESCRIPTION
### What is this ?
Fix the bug missed in #507 .

Correct the following python scripts in rqt gui:

- `map` -> `list(map)`
- `chr()` -> `[]` for `uint8 []`
- different cases for python2 and python3 for `ord()`