### PR TITLE
Fix the bug about the conversion of inertia tensor from SolidEdge

### DIFF
--- a/aerial_robot_model/script/solidedge_cog_inertia_tensor_converter.py
+++ b/aerial_robot_model/script/solidedge_cog_inertia_tensor_converter.py
@@ -36,9 +36,9 @@ cog_z = float(argvs[3]) * .001
 i_xx = float(argvs[4])
 i_yy = float(argvs[5])
 i_zz = float(argvs[6])
-i_xy = float(argvs[7])
-i_xz = float(argvs[8])
-i_yz = float(argvs[9])
+i_xy = -float(argvs[7])
+i_xz = -float(argvs[8])
+i_yz = -float(argvs[9])
 mass = float(argvs[10])
 
 cog_i_xx = i_xx - (cog_y * cog_y  + cog_z * cog_z) * mass


### PR DESCRIPTION
### What is this 

Fix the bug about the conversion of inertia tensor elements from SolidEdge result.

### Detail

The sign of value `I_xy, I_xz, I_yz` should be negative.