### PR TITLE
[DRAGON] add IIR LPF for IMU gyro data

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/Spine/spine.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/Spine/spine.cpp
@@ -176,8 +176,6 @@ namespace Spine
     if(gimbal_servo_num  == 2 * slave_num_)
       {
         uav_model_ = spinal::UavInfo::DRAGON;
-        /* special smoothing flag for dragon */
-        estimator_->getAttEstimator()->setPubAccGryoOnlyFlag(true);
       }
 
     servo_state_msg_.servos_length = servo_with_send_flag_.size();

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
@@ -703,13 +703,9 @@ void  AttitudeController::setUavModel(int8_t uav_model)
   /* check the uav model which has spine system */
   uav_model_ = uav_model;
 
-  if(uav_model_ == spinal::UavInfo::DRAGON)
-    {
-      rotor_devider_ = 2; // dual-rotor
-
-      estimator_->getAttEstimator()->setPubAccGryoOnlyFlag(true); // speical imu publish for dragon
-    }
-
+  if(uav_model_ == spinal::UavInfo::DRAGON) {
+    rotor_devider_ = 2; // dual-rotor
+  }
 }
 
 void AttitudeController::pMatrixInertiaCallback(const spinal::PMatrixPseudoInverseWithInertia& msg)

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/state_estimate/attitude/attitude_estimate.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/state_estimate/attitude/attitude_estimate.h
@@ -53,7 +53,7 @@ class AttitudeEstimate
 public:
   ~AttitudeEstimate(){}
 #ifdef SIMULATION
-  AttitudeEstimate(): pub_acc_gyro_only_flag_(false)
+  AttitudeEstimate()
   {
     tf_desired_coord_.setIdentity();
   }
@@ -98,8 +98,7 @@ public:
     desire_coord_sub_("desire_coordinate", &AttitudeEstimate::desireCoordCallback, this ),
     mag_declination_srv_("mag_declination", &AttitudeEstimate::magDeclinationCallback,this),
     imu_list_(1),
-    imu_weights_(1,1),
-	pub_acc_gyro_only_flag_(false)
+    imu_weights_(1,1)
   {}
 
   void init(IMU* imu, GPS* gps, ros::NodeHandle* nh)
@@ -194,14 +193,7 @@ public:
           {
             imu_msg_.mag_data[i] = estimator_->getMag(Frame::BODY)[i];
             imu_msg_.acc_data[i] = estimator_->getAcc(Frame::BODY)[i];
-
-            if(pub_acc_gyro_only_flag_)
-              {
-                imu_msg_.gyro_data[i] = estimator_->getSmoothAngular(Frame::BODY)[i];
-                imu_msg_.mag_data[i] = estimator_->getAngular(Frame::BODY)[i]; // workaround to publish the raw gyro data for control in ROS.
-              }
-            else
-              imu_msg_.gyro_data[i] = estimator_->getAngular(Frame::BODY)[i];
+            imu_msg_.gyro_data[i] = estimator_->getAngular(Frame::BODY)[i];
 #if ESTIMATE_TYPE == COMPLEMENTARY
             imu_msg_.angles[i] = estimator_->getAttitude(Frame::BODY)[i]; // get the attitude at body frame3
 #endif
@@ -245,7 +237,6 @@ public:
   inline const ap::Vector3f getAngular(uint8_t frame) { return estimator_->getAngular(frame); }
   inline const ap::Vector3f getSmoothAngular(uint8_t frame) { return estimator_->getSmoothAngular(frame); }
   inline const ap::Matrix3f getDesiredCoord()  { return estimator_->getDesiredCoord(); }
-  inline void setPubAccGryoOnlyFlag(bool flag) { pub_acc_gyro_only_flag_ = flag; }
 
   static const uint8_t IMU_PUB_INTERVAL = 5; //10-> 100Hz, 2 -> 500Hz
   static const uint8_t ATTITUDE_PUB_INTERVAL = 100; //100 -> 10Hz
@@ -256,7 +247,6 @@ private:
 
   spinal::Imu imu_msg_;
   geometry_msgs::Vector3Stamped attitude_msg_;
-  bool pub_acc_gyro_only_flag_;
 
 #ifdef SIMULATION
   ros::Subscriber desire_coord_sub_;

--- a/robots/dragon/config/quad/egomotion_estimation/euclid_201709/FullVectoring.yaml
+++ b/robots/dragon/config/quad/egomotion_estimation/euclid_201709/FullVectoring.yaml
@@ -43,5 +43,7 @@ estimation:
 sensor_plugin:
         imu:
                 estimate_mode: 3 # 1<<0 + 1<<1
+                sample_freq: 200.0
+                cutoff_freq: 10.0
         mocap:
                 estimate_mode: 6 # 1<<1 + 1<<2

--- a/robots/dragon/include/dragon/sensor/imu.h
+++ b/robots/dragon/include/dragon/sensor/imu.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <aerial_robot_estimation/sensor/imu.h>
+#include <geometry_msgs/Vector3Stamped.h>
 
 using namespace Eigen;
 using namespace std;
@@ -84,6 +85,9 @@ namespace sensor_plugin
     boost::mutex vel_mutex_;
     tf::Vector3 filtered_vel_cog_;
     tf::Vector3 filtered_omega_cog_;
+    IirFilter lpf_omega_; // for gyro
+
+    ros::Publisher omega_filter_pub_; // debug
   };
 };
 


### PR DESCRIPTION
### What is this?

Add IIR LPF for IMU gyro data in the dragon imu sensor plugin

### Details

So far, we filtered the gyro data inside spinal to get filtered values for better control performance for DRAGON. However, this workaround need to occupy the magnetic data slot as follows:
https://github.com/jsk-ros-pkg/jsk_aerial_robot/compare/master...tongtybj:aerial_robot:PR/dragon/imu/lpf?expand=1#diff-39dac9e38e440c9379ca2db26aa1ac489801d3476b73c5e9de2fbb30164036c1L201

For better solution, we add new LPF in DRAGON::Imu sensor plugin,  which uses the  IIR filter to process raw gyro data. This can provide the same filtering performance with the workaround solution. 
