### PR TITLE
[aerial_robot_base]  Explicitly stop timer and async spinner for safe destruction

### DIFF
--- a/aerial_robot_base/include/aerial_robot_base/aerial_robot_base.h
+++ b/aerial_robot_base/include/aerial_robot_base/aerial_robot_base.h
@@ -14,7 +14,7 @@ class AerialRobotBase
 {
  public:
   AerialRobotBase(ros::NodeHandle nh, ros::NodeHandle nh_private);
-  ~AerialRobotBase() {};
+  ~AerialRobotBase();
 
   void mainFunc(const ros::TimerEvent & e);
 

--- a/aerial_robot_base/src/aerial_robot_base.cpp
+++ b/aerial_robot_base/src/aerial_robot_base.cpp
@@ -76,6 +76,15 @@ AerialRobotBase::AerialRobotBase(ros::NodeHandle nh, ros::NodeHandle nh_private)
 
 }
 
+AerialRobotBase::~AerialRobotBase()
+{
+  // stop manually to avoid following error (message)
+  // terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
+  // what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
+  main_timer_.stop();
+  main_loop_spinner_.stop();
+}
+
 void AerialRobotBase::mainFunc(const ros::TimerEvent & e)
 {
   navigator_->update();


### PR DESCRIPTION
### What is this 

Explicitly stop timer and async spinner for the safe destruction of AerialRobotBase

### Detail

Without this patch, there is following error messsage when kill the aerial_robot_base node:
```bash
 terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
 what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
```

