### PR TITLE
[Github Action] do not cancel all in-progress in ros_test jobs.

### DIFF
--- a/.github/workflows/ros_test.yml
+++ b/.github/workflows/ros_test.yml
@@ -3,8 +3,9 @@ on: [push, pull_request]
 jobs:
   ci:
     runs-on: ubuntu-latest
-    name: ci
+    name: ros_build_test
     strategy:
+      fail-fast: false
       matrix:
         include:
           - ROS_DISTRO : kinetic


### PR DESCRIPTION
# What is this

Currently rule in CI will cancel all in-progress jobs if any of jobs fails. 
ROS test for different ros distribution may have random failure becuase of the ros tests.
So allow to ignore failure from other jobs.