### PR TITLE
[Spinal][rosserial] increase the size of OUTPUT_SIZE for publisher

### DIFF
--- a/aerial_robot_nerve/spinal/src/ros_lib/ros.h
+++ b/aerial_robot_nerve/spinal/src/ros_lib/ros.h
@@ -40,7 +40,7 @@
 namespace ros
 {
   /* be sure the max size of publisher and subscriber, as well as the size of message */
-  typedef NodeHandleStm_<50, 50, 512, 512> NodeHandle;
+  typedef NodeHandleStm_<50, 50, 512, 1024> NodeHandle;
 }
 
 #endif


### PR DESCRIPTION
### What is this

The OUTPUT_SIZE for publisher in spinal size is too limited, so we cannot send large size message (e.g., servo state from all neurons). Incease to double size of 1024 bytes for sufficient space.
