### PR TITLE
[Simulation][Rotor] do not add noise if the target PWM is close to zero 

### DIFF
--- a/aerial_robot_simulation/include/aerial_robot_simulation/rotor_handle.h
+++ b/aerial_robot_simulation/include/aerial_robot_simulation/rotor_handle.h
@@ -84,7 +84,7 @@ namespace hardware_interface
 
     inline void setForce(double target_force, bool direct = false)
     {
-      if(direct)
+      if(direct || target_force < 1e-6)
         {
           *force_ = target_force;
         }


### PR DESCRIPTION
### What is this

In simulation, do not add noise if the target PWM is close to zero.

### Detail

Current system add noise on target PWM to simulate the real rotor behabvior regardless of the PWM value. However, in real robot, if the PWM is zero, there is no noise.