### PR TITLE
[Mocap] refactor the subscruber transport hint for pose subscriber

### DIFF
--- a/aerial_robot_estimation/src/sensor/mocap.cpp
+++ b/aerial_robot_estimation/src/sensor/mocap.cpp
@@ -70,13 +70,15 @@ namespace sensor_plugin
 
       std::string topic_name;
       getParam<std::string>("mocap_sub_name", topic_name, std::string("pose"));
+      ros::TransportHints hint = ros::TransportHints();
+      bool mocap_udp;
+      getParam<bool>("mocap_udp", mocap_udp, false);
+      if (mocap_udp) {
+	hint = ros::TransportHints().udp();
+	ROS_INFO("use UDP for mocap subscribe");
+      }
 
-#ifdef ARM_MELODIC //https://github.com/ros/ros_comm/issues/1404
-      mocap_sub_ = nh_.subscribe(topic_name, 1, &Mocap::poseCallback, this); // since we do not use time_sync mode for mocap, so only need the latest value.
-#else
-      mocap_sub_ = nh_.subscribe(topic_name, 1, &Mocap::poseCallback, this, ros::TransportHints().udp()); // since we do not use time_sync mode for mocap, so only need the latest value.
-      ROS_INFO("use UDP for mocap topic subscriber in ground truth mode");
-#endif
+      mocap_sub_ = nh_.subscribe(topic_name, 1, &Mocap::poseCallback, this, hint); // buffer size 1: only need the latest value.
       nhp_.param("ground_truth_sub_name", topic_name, std::string("ground_truth"));
       ground_truth_sub_ = nh_.subscribe(topic_name, 1, &Mocap::groundTruthCallback, this);
     }


### PR DESCRIPTION
### What is this 

The transport hint setting for mocap pose subscriber is broken. Refactor the setting rule for better use. 

### Detail

Add `mocap/mocap_udp: true` in `StateEstimation.yaml` can switch to UDP mode if necessary.

StateEstimation.yaml for hydrus:
https://github.com/jsk-ros-pkg/jsk_aerial_robot/blob/master/robots/hydrus/config/quad/default_mode_201907/StateEstimation.yaml#L48-L49

