### PR TITLE
[Spinal][rosserial] use UART for STM32H7 as default

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7/Inc/main.h
+++ b/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7/Inc/main.h
@@ -47,7 +47,7 @@ extern "C" {
 
 /* Exported macro ------------------------------------------------------------*/
 /* USER CODE BEGIN EM */
-#define USE_ETH // comment out if we do not have eth
+// #define USE_ETH // comment out if we do not have eth
 /* USER CODE END EM */
 
 void HAL_TIM_MspPostInit(TIM_HandleTypeDef *htim);


### PR DESCRIPTION
### What is this

use UART for spinal STM32H7 as default

### Detail

STM32H7 support both UART and Ethernet for rosserial, and the previous default is Ethernet, which is minor case. So we change the default to UART for most of the common user.