### PR TITLE
[Spinal][motor][PWM] set the desired PWM output to timer handllers 

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
@@ -182,7 +182,6 @@ void AttitudeController::pwmsControl(void)
     Spine::setMotorPwm(target_pwm_[i] * 2000 - 1000, i);
 #endif
   }
-  return;
 #endif
 
   /* direct pwm type */


### PR DESCRIPTION
### What is this

Set the desired PWM output to timer handllers regardless of the CAN connection.

### Detail

So far, we skip the output to Timer handler if we connect to CAN by "return", which make it very inconvenient to use TImer handler if we define the macro of "NERVE_COMM". 

This unneceesary skip should be removed.
