### PR TITLE
[Spinal][CAN] refactor the process when no neuron connected

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/Spine/spine.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/Spine/spine.cpp
@@ -214,6 +214,8 @@ namespace Spine
 
   void send()
   {
+    if (slave_num_ == 0) return;
+
     if(HAL_GetTick() < can_tx_idle_start_time_ + CAN_TX_PAUSE_TIME) return;
 
     if(HAL_GetTick() % 2 == 0) {
@@ -228,6 +230,8 @@ namespace Spine
 
   void update(void)
   {
+    if (slave_num_ == 0) return;
+
     for (int i = 0; i < slave_num_; i++)
       neuron_.at(i).can_imu_.update();
 
@@ -284,7 +288,7 @@ namespace Spine
 
     if(now_time - last_connected_time_ > 1000 /* ms */)
       {
-        if(nh_->connected()) nh_->logerror("CAN is not connected");
+        if(nh_->connected()) nh_->logerror("CAN disconnected!!");
         last_connected_time_ = now_time;
       }
   }


### PR DESCRIPTION
### What is this

No CAN communication if there is no any Neuron found in initialization phase.

### Details

So far, Spinal will keep trying to contact with Neurons even if there is no any Neuron connected and detected. This will cause an very annoying message to rosserial "CAN is not connected". This PR patch avoids this message and also save the computation resource in spinal when Neurons are not connected. 

