### PR TITLE
[Spinal][Neuron][Servo] solve the joint pulley round offset problem

### DIFF
--- a/aerial_robot_nerve/neuron/neuronlib/CAN/can_constants.h
+++ b/aerial_robot_nerve/neuron/neuronlib/CAN/can_constants.h
@@ -51,6 +51,7 @@ namespace CAN {
 	constexpr uint8_t BOARD_CONFIG_SET_DYNAMIXEL_TTL_RS485_MIXED = 8;
         constexpr uint8_t BOARD_CONFIG_SET_EXTERNAL_ENCODER_FLAG = 9;
         constexpr uint8_t BOARD_CONFIG_SET_RESOLUTION_RATIO = 10;
+	constexpr uint8_t BOARD_CONFIG_SET_SERVO_ROUND_OFFSET = 11;
 }
 
 

--- a/aerial_robot_nerve/neuron/neuronlib/Initializer/initializer.cpp
+++ b/aerial_robot_nerve/neuron/neuronlib/Initializer/initializer.cpp
@@ -180,6 +180,13 @@ void Initializer::receiveDataCallback(uint8_t message_id, uint32_t DLC, uint8_t*
                     }
                     break;
 		}
+		case CAN::BOARD_CONFIG_SET_SERVO_ROUND_OFFSET:
+		{
+			uint8_t servo_index = data[1];
+			int32_t ref_value = ((data[5] << 24) & 0xFF000000) | ((data[4] << 16) & 0xFF0000) | ((data[3] << 8) & 0xFF00) | ((data[2] << 0) & 0xFF);
+			servo_.servo_handler_.setRoundOffset(servo_index, ref_value);
+			break;
+		}
 		default:
 			break;
 		}

--- a/aerial_robot_nerve/neuron/neuronlib/Servo/Dynamixel/dynamixel_serial.h
+++ b/aerial_robot_nerve/neuron/neuronlib/Servo/Dynamixel/dynamixel_serial.h
@@ -278,7 +278,7 @@ private:
 class ServoData {
 public:
 	ServoData(){}
-	ServoData(uint8_t id): id_(id), torque_enable_(false), first_get_pos_flag_(true){}
+  ServoData(uint8_t id): id_(id), torque_enable_(false), first_get_pos_flag_(true), internal_offset_(0){}
 
 	uint8_t id_;
   	int32_t present_position_;
@@ -323,6 +323,7 @@ public:
   void reboot(uint8_t servo_index);
   void setTorque(uint8_t servo_index);
   void setHomingOffset(uint8_t servo_index);
+  void setRoundOffset(uint8_t servo_index, int32_t ref_value);
   void setPositionGains(uint8_t servo_index);
   void setProfileVelocity(uint8_t servo_index);
   void setCurrentLimit(uint8_t servo_index);

--- a/aerial_robot_nerve/neuron/neuronlib/Servo/Dynamixel/dynamixel_serial.h
+++ b/aerial_robot_nerve/neuron/neuronlib/Servo/Dynamixel/dynamixel_serial.h
@@ -303,7 +303,7 @@ public:
 	bool torque_enable_;
 	bool first_get_pos_flag_;
 
-	int32_t getNewHomingOffset() const {return calib_value_ + homing_offset_ - present_position_;}
+	void updateHomingOffset() { homing_offset_ = calib_value_ - present_position_;}
 	void setPresentPosition(int32_t present_position) {present_position_ = present_position + internal_offset_;}
 	int32_t getPresentPosition() const {return present_position_;}
 	void setGoalPosition(int32_t goal_position) {goal_position_ = resolution_ratio_ * goal_position - internal_offset_;}

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/CANDevice/initializer/can_initializer.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/CANDevice/initializer/can_initializer.cpp
@@ -155,6 +155,20 @@ void CANInitializer::configDevice(const spinal::SetBoardConfig::Request& req)
 			sendMessage(CAN::MESSAGEID_RECEIVE_BOARD_CONFIG_REQUEST, slave_id, 2, send_data, 1);
 			break;
 		}
+		case CAN::BOARD_CONFIG_SET_SERVO_ROUND_OFFSET:
+		{
+			uint8_t servo_index = static_cast<uint8_t>(req.data[1]);
+			int32_t ref_value = req.data[2];
+			uint8_t send_data[6];
+			send_data[0] = CAN::BOARD_CONFIG_SET_SERVO_ROUND_OFFSET;
+			send_data[1] = servo_index;
+			send_data[2] = ref_value & 0xFF;
+			send_data[3] = (ref_value >> 8) & 0xFF;
+			send_data[4] = (ref_value >> 16) & 0xFF;
+			send_data[5] = (ref_value >> 24) & 0xFF;
+			sendMessage(CAN::MESSAGEID_RECEIVE_BOARD_CONFIG_REQUEST, slave_id, 6, send_data, 1);
+			break;
+		}
 		default:
 			break;
 	}

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/Spine/spine.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/Spine/spine.cpp
@@ -111,8 +111,10 @@ namespace Spine
   {
     /* Pause the spinal sending command for neuron to have enough time for flashmemory erase&write */
     can_tx_idle_start_time_ = HAL_GetTick();
+    // TODO: change the return value to bool
     can_initializer_.configDevice(req);
 
+    // TODO: please add string type message for consoling
     res.success = true;
   }
 

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_constants.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_constants.h
@@ -52,6 +52,7 @@ namespace CAN {
 	constexpr uint8_t BOARD_CONFIG_SET_DYNAMIXEL_TTL_RS485_MIXED = 8;
         constexpr uint8_t BOARD_CONFIG_SET_EXTERNAL_ENCODER_FLAG = 9;
         constexpr uint8_t BOARD_CONFIG_SET_RESOLUTION_RATIO = 10;
+	constexpr uint8_t BOARD_CONFIG_SET_SERVO_ROUND_OFFSET = 11;
 }
 
 

--- a/aerial_robot_nerve/spinal/scripts/servo_rough_calib.py
+++ b/aerial_robot_nerve/spinal/scripts/servo_rough_calib.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+import rospy
+import rospkg
+from std_srvs.srv import SetBool, SetBoolRequest
+from spinal.srv import SetBoardConfig, SetBoardConfigRequest, GetBoardInfo
+from sensor_msgs.msg import JointState
+import socket
+import rosgraph
+import math
+
+class JointRoughCalib:
+    def __init__(self):
+
+        master = rosgraph.Master('/rostopic')
+        try:
+            _, _, srvs = master.getSystemState()
+        except socket.error:
+            raise ROSTopicIOException('Unable to communicate with master!')
+        board_info_srvs = [srv[0] for srv in srvs if '/set_board_info' in srv[0]]
+        # choose the first robot name
+
+        # robot_ns = board_info_srvs[0].split('/get_board_info')[0]
+        robot_ns = 'dragon'
+
+        rospy.loginfo('robot name is {}'.format(robot_ns))
+
+        # capture the joint angles
+        self.joint_states = None
+        self.joint_sub = rospy.Subscriber(robot_ns + '/joint_states', JointState, self.cb)
+        while self.joint_states is None:
+            rospy.loginfo("wait for joint states...")
+            rospy.sleep(1.0)
+
+        config = rospy.get_param(robot_ns + '/servo_controller/joints')
+        angle_scale = config['angle_scale']
+        zero_point_offset = config['zero_point_offset']
+
+        # get calib angles
+        calib_angles = rospy.get_param(robot_ns + '/joints/calib_angles', None) # dict
+
+        if calib_angles is None:
+            # set calib angles according to
+
+            rospy.loginfo('get joint calib angles from rosparameter ({})'.format(robot_ns + '/servo_controller/joints'))
+
+            calib_angles = dict()
+            for conf in [v for k, v in config.items() if 'controller' in k]:
+
+                if 'simulation' not in conf:
+                    continue
+
+                simulation_config = conf['simulation']
+
+                if 'init_value' in simulation_config:
+                    calib_angles[conf['name']] = simulation_config['init_value']
+        else:
+            if not isinstance(calib_angles, dict):
+                rospy.logwarn('type calib_angles should be dictionary, should not be {}'.format(type(calib_angles)))
+                return;
+
+
+        calib_joints = dict()
+        for k, v in calib_angles.items():
+            calib_joints[k] = {'calib_angle': v}
+
+        # get neuron info for servo
+        joint_id_name_map = {v['id']: v['name'] for k, v in config.items() if 'controller' in k}
+        get_board_info_client = rospy.ServiceProxy(robot_ns + '/get_board_info', GetBoardInfo)
+        try:
+            res = get_board_info_client()
+            c = 0
+            for i, b in enumerate(res.boards):
+                for j, s in enumerate(b.servos):
+
+                    if c not in joint_id_name_map.keys():
+                        # not joint type (maybe gimbal)
+                        continue
+
+                    name = joint_id_name_map[c]
+
+                    if name not in calib_joints.keys():
+                        # is not in calib target
+                        continue
+
+                    config = calib_joints[name]
+                    config["slave_id"] = b.slave_id
+                    config["servo_id"] = s.id
+                    c += 1
+
+        except rospy.ServiceException as e:
+            rospy.logerr("/get_board_info service call failed: %s"%e)
+
+
+        rospy.loginfo('calib joints are {}, angle_scale: {}, zero_point_offset: {}'.format(calib_joints, angle_scale, zero_point_offset))
+
+
+        # disable joint servo
+        rospy.loginfo('disable joint servo')
+        self.joint_servo_client_ = rospy.ServiceProxy(robot_ns + '/joints/torque_enable', SetBool)
+
+        try:
+            req = SetBoolRequest(False)
+            res = self.joint_servo_client_(req)
+        except rospy.ServiceException as e:
+            print('/joints/torque_enable call failed: {}'.format(e))
+        rospy.loginfo('succeed')
+
+        # joint angle calib (update round offset)
+        set_board_config_client = rospy.ServiceProxy(robot_ns + '/set_board_config', SetBoardConfig)
+        req = SetBoardConfigRequest()
+        for k, v in calib_joints.items():
+            if k not in self.joint_states.name:
+                rospy.logerr("there is no {} in joint states".format(k))
+                continue
+
+            index = self.joint_states.name.index(k)
+            angle = self.joint_states.position[index]
+            ref = v['calib_angle']
+
+            diff = math.fabs(angle - ref)
+            thresh = 0.2 # 0.2 rad as a hard-coding angle
+
+            if diff > thresh:
+                rospy.loginfo("calibrate {} for large round offset, current: {}, ref: {}".format(k, angle, ref))
+                req = SetBoardConfigRequest()
+                req.command = 11 # WIP: please refer to spinal/mcu_project/lib/Jsk_Lib/CAN/can_constants.h
+                req.data.append(int(v['slave_id']))
+                req.data.append(int(v['servo_id']))
+                raw_ref = ref / angle_scale + zero_point_offset
+                req.data.append(int(raw_ref))
+                rospy.loginfo('call service')
+                rospy.loginfo('command: ' + str(req.command))
+                rospy.loginfo('data: ' + str(req.data))
+                try:
+                    res = set_board_config_client(req)
+                    rospy.loginfo(bool(res.success))
+                    timeout = 3
+                    rospy.sleep(timeout) # WIP: wait for finish update in spinal-neuron
+                    rospy.loginfo('wait {} [sec] for update angle'.format(timeout))
+
+                    # check the joint angle update
+                    angle = self.joint_states.position[index]
+                    diff = math.fabs(angle - ref)
+                    if diff > thresh:
+                        rospy.logerror("calibrate fail for {}, current: {}, ref: {}".format(k, angle, ref))
+                        return
+                except rospy.ServiceException as e:
+                    print("/set_board_config service call failed: {}".format(e))
+
+
+        # enable joint servo again
+        rospy.loginfo('enable joint servo')
+        self.joint_servo_client_ = rospy.ServiceProxy(robot_ns + '/joints/torque_enable', SetBool)
+        try:
+            res = self.joint_servo_client_(SetBoolRequest(True))
+        except rospy.ServiceException as e:
+            print('/joints/torque_enable call failed: {}'.format(e))
+        rospy.loginfo('succeed')
+
+    def cb(self, msg):
+        self.joint_states = msg
+
+if __name__=="__main__":
+
+    rospy.init_node("joint_rough_calib")
+
+    node = JointRoughCalib()

--- a/robots/dragon/launch/includes/euclid_201709/sensors.launch.xml
+++ b/robots/dragon/launch/includes/euclid_201709/sensors.launch.xml
@@ -20,6 +20,11 @@
         <!--
             <include file="$(find aerial_robot_base)/launch/external_module/mocap.launch" />
         -->
+
+        <!-- joint rough calib -->
+        <node pkg="spinal" type="servo_rough_calib.py" name="servo_rough_calib" output="screen">
+          <param name="robot_ns" value="$(arg robot_ns)" />
+        </node>
       </group>
     </group>
 


### PR DESCRIPTION
### What is this

This PR can compensate the round offset between servo and joint. 

### Detail

The joint pulley may make an undesired round offset between servo abs encoder and joint real angle. 
For example, in case of  a pulley ratio of 1:2 (servo:joint), the servo encoder need a true value over 360 deg for joint angle with more than 180 deg. But the abs encoder  can only have an initial value around 0~360 deg, which means the abs encoder will give a very small initial value theta for joint angle more than 180 deg.  

This PR enables manual compensation by user with rosservice of `Spinal/SetBoardConfig`. Command ID is `11`, and the command data should be `[slave_id, servo_index, compensate_servo_angle]`.

We also provide an automatic compensate code:
```
$ rosrun spinal servo_rough_calib.py
```
This will automatically find the initial joint (servo) angles from the [Servo.yaml](https://github.com/jsk-ros-pkg/jsk_aerial_robot/blob/master/robots/dragon/config/quad/Servo.yaml). The joint angle in simualtion (e.g., https://github.com/jsk-ros-pkg/jsk_aerial_robot/blob/master/robots/dragon/config/quad/Servo.yaml#L32-L33) will be used to compensate the pully round offset.

