### PR TITLE
[Hydrus XI] refactor the description about dependency

### DIFF
--- a/robots/hydrus_xi/CMakeLists.txt
+++ b/robots/hydrus_xi/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(catkin REQUIRED COMPONENTS
   aerial_robot_control
   aerial_robot_model
   aerial_robot_msgs
-  aerial_robot_simulation
   angles
   hydrus
   roscpp
@@ -22,7 +21,7 @@ find_package(OsqpEigen REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES  hydrus_xi_fully_actuated_robot_model
-  CATKIN_DEPENDS  aerial_robot_base aerial_robot_control aerial_robot_model aerial_robot_msgs aerial_robot_simulation angles hydrus roscpp rospy spinal
+  CATKIN_DEPENDS  aerial_robot_base aerial_robot_control aerial_robot_model aerial_robot_msgs angles hydrus roscpp rospy spinal
   )
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/robots/hydrus_xi/package.xml
+++ b/robots/hydrus_xi/package.xml
@@ -13,13 +13,13 @@
   <depend>aerial_robot_control</depend>
   <depend>aerial_robot_model</depend>
   <depend>aerial_robot_msgs</depend>
-  <depend>aerial_robot_simulation</depend>
   <depend>angles</depend>
   <depend>hydrus</depend>
   <depend>roscpp</depend>
   <depend>rospy</depend>
   <depend>spinal</depend>
 
+  <exec_depend>aerial_robot_simulation</exec_depend>
   <test_depend>rostest</test_depend>
 
   <export>


### PR DESCRIPTION
### What is this

package of `aerial_robot_simualtion` should only be an `exec_dependency` for launch file, but not a `build_dependency`.