### PR TITLE
[Aerial Robot Control] landing, halt command during vel acc-based mode

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
+++ b/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
@@ -485,6 +485,10 @@ namespace aerial_robot_navigation
       // set the velocty to zero
       target_vel_.setX(0);
       target_vel_.setY(0);
+
+      // set the acceleration to zero
+      setTargetAccX(0);
+      setTargetAccY(0);
     }
 
     void setTargetZFromCurrentState()

--- a/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
+++ b/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
@@ -478,6 +478,7 @@ namespace aerial_robot_navigation
 
     void setTargetXyFromCurrentState()
     {
+      setXyControlMode(POS_CONTROL_MODE);
       tf::Vector3 pos_cog = estimator_->getPos(Frame::COG, estimate_mode_);
       target_pos_.setX(pos_cog.x());
       target_pos_.setY(pos_cog.y());

--- a/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
+++ b/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
@@ -404,7 +404,6 @@ namespace aerial_robot_navigation
       if(!teleop_flag_) return;
 
       setNaviState(LAND_STATE);
-      setXyControlMode(POS_CONTROL_MODE);
 
       setTargetXyFromCurrentState();
       setTargetYawFromCurrentState();
@@ -419,7 +418,6 @@ namespace aerial_robot_navigation
       force_landing_flag_ = true;
 
       setNaviState(STOP_STATE);
-      setXyControlMode(POS_CONTROL_MODE);
       setTargetXyFromCurrentState();
       setTargetYawFromCurrentState();
       setTargetPosZ(estimator_->getLandingHeight());

--- a/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
+++ b/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
@@ -404,6 +404,7 @@ namespace aerial_robot_navigation
       if(!teleop_flag_) return;
 
       setNaviState(LAND_STATE);
+      setXyControlMode(POS_CONTROL_MODE);
 
       setTargetXyFromCurrentState();
       setTargetYawFromCurrentState();
@@ -418,6 +419,7 @@ namespace aerial_robot_navigation
       force_landing_flag_ = true;
 
       setNaviState(STOP_STATE);
+      setXyControlMode(POS_CONTROL_MODE);
       setTargetXyFromCurrentState();
       setTargetYawFromCurrentState();
       setTargetPosZ(estimator_->getLandingHeight());

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -408,6 +408,7 @@ void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
 
       setNaviState(LAND_STATE);
       //update
+      setXyControlMode(POS_CONTROL_MODE)
       setTargetXyFromCurrentState();
       setTargetYawFromCurrentState();
       setTargetPosZ(estimator_->getLandingHeight());
@@ -638,6 +639,7 @@ void BaseNavigator::update()
       if(normal_land && !force_att_control_flag_)
         {
           setNaviState(LAND_STATE);
+          setXyControlMode(POS_CONTROL_MODE);
           setTargetXyFromCurrentState();
           setTargetYawFromCurrentState();
           setTargetPosZ(estimator_->getLandingHeight());

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -408,7 +408,6 @@ void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
 
       setNaviState(LAND_STATE);
       //update
-      setXyControlMode(POS_CONTROL_MODE)
       setTargetXyFromCurrentState();
       setTargetYawFromCurrentState();
       setTargetPosZ(estimator_->getLandingHeight());
@@ -639,7 +638,6 @@ void BaseNavigator::update()
       if(normal_land && !force_att_control_flag_)
         {
           setNaviState(LAND_STATE);
-          setXyControlMode(POS_CONTROL_MODE);
           setTargetXyFromCurrentState();
           setTargetYawFromCurrentState();
           setTargetPosZ(estimator_->getLandingHeight());


### PR DESCRIPTION
### What is this
Debug in landing, halt command in XyControlMode =VEL_CONTROL_MODE, and ACC_CONTROL_MODE

### Detail

- set POS_CONTROL_MODE when navigator get landing, halt topic
- setTargetAcc = 0 in setTargetXyFromCurrentState