### PR TITLE
[Estimation][VO] Refactor throttle/decimate process

### DIFF
--- a/aerial_robot_estimation/include/aerial_robot_estimation/sensor/vo.h
+++ b/aerial_robot_estimation/include/aerial_robot_estimation/sensor/vo.h
@@ -75,6 +75,7 @@ namespace sensor_plugin
     ros::Timer  servo_control_timer_;
 
     /* ros param */
+    double throttle_rate_;
     double level_pos_noise_sigma_;
     double z_pos_noise_sigma_;
     double vel_noise_sigma_;


### PR DESCRIPTION
### What is this

Revert the throttle/decimate process inside the callback process, which allows to set larger interval between two valid data from VO sensor.

### Details

Some of the VO sensors (e.g., Realsense T265) provides the odometry with a high frequency that is unecessary for our fusion system. So, a simple decimation process is designed here.