### PR TITLE
[Aerial Robot Model][Underactuated][Plugin] fix the wrong args assignment for model constructor

### DIFF
--- a/aerial_robot_model/src/model/plugin/multirotor_robot_model.cpp
+++ b/aerial_robot_model/src/model/plugin/multirotor_robot_model.cpp
@@ -36,7 +36,7 @@
 #include <aerial_robot_model/model/plugin/multirotor_robot_model.h>
 
 MultirotorRobotModel::MultirotorRobotModel(bool init_with_rosparam, bool verbose, double fc_t_min_thre, double epsilon):
-  RobotModel(init_with_rosparam, verbose, 0, fc_t_min_thre, epsilon)
+  RobotModel(init_with_rosparam, verbose, true, 0, fc_t_min_thre, epsilon)
 {
 }
 

--- a/aerial_robot_model/src/model/plugin/underactuated_tilted_robot_model.cpp
+++ b/aerial_robot_model/src/model/plugin/underactuated_tilted_robot_model.cpp
@@ -36,7 +36,7 @@
 #include <aerial_robot_model/model/plugin/underactuated_tilted_robot_model.h>
 
 UnderactuatedTiltedRobotModel::UnderactuatedTiltedRobotModel(bool init_with_rosparam, bool verbose, double fc_t_min_thre, double epsilon):
-  RobotModel(init_with_rosparam, verbose, fc_t_min_thre, 0, epsilon)
+  RobotModel(init_with_rosparam, verbose, true, 0, fc_t_min_thre, epsilon)
 {
 
   // calc static thrust

--- a/robots/dragon/include/dragon/control/full_vectoring_control.h
+++ b/robots/dragon/include/dragon/control/full_vectoring_control.h
@@ -74,7 +74,7 @@ namespace aerial_robot_control
     ros::Publisher interfrence_marker_pub_;
 
     boost::shared_ptr<Dragon::FullVectoringRobotModel> dragon_robot_model_;
-    boost::shared_ptr<aerial_robot_model::RobotModel> robot_model_for_control_;
+    boost::shared_ptr<aerial_robot_model::transformable::RobotModel> robot_model_for_control_;
     std::vector<float> target_base_thrust_;
     std::vector<double> target_gimbal_angles_;
     Eigen::VectorXd target_vectoring_f_;

--- a/robots/dragon/include/dragon/model/full_vectoring_robot_model.h
+++ b/robots/dragon/include/dragon/model/full_vectoring_robot_model.h
@@ -55,7 +55,7 @@ namespace Dragon
     virtual ~FullVectoringRobotModel() = default;
 
 
-    inline boost::shared_ptr<aerial_robot_model::RobotModel> getRobotModelForPlan() { return robot_model_for_plan_;}
+    inline boost::shared_ptr<aerial_robot_model::transformable::RobotModel> getRobotModelForPlan() { return robot_model_for_plan_;}
     inline const Eigen::VectorXd& getHoverVectoringF() const {return hover_vectoring_f_;}
 
     const std::vector<int> getRollLockedGimbal()
@@ -88,7 +88,7 @@ namespace Dragon
 
   private:
 
-    boost::shared_ptr<aerial_robot_model::RobotModel> robot_model_for_plan_;
+    boost::shared_ptr<aerial_robot_model::transformable::RobotModel> robot_model_for_plan_;
 
     Eigen::VectorXd hover_vectoring_f_;
 

--- a/robots/dragon/src/control/full_vectoring_control.cpp
+++ b/robots/dragon/src/control/full_vectoring_control.cpp
@@ -18,7 +18,7 @@ void DragonFullVectoringController::initialize(ros::NodeHandle nh, ros::NodeHand
   rosParamInit();
 
   dragon_robot_model_ = boost::dynamic_pointer_cast<Dragon::FullVectoringRobotModel>(robot_model);
-  robot_model_for_control_ = boost::make_shared<aerial_robot_model::RobotModel>();
+  robot_model_for_control_ = boost::make_shared<aerial_robot_model::transformable::RobotModel>();
 
   /* initialize the gimbal target angles */
   target_base_thrust_.resize(motor_num_);

--- a/robots/dragon/src/model/full_vectoring_robot_model.cpp
+++ b/robots/dragon/src/model/full_vectoring_robot_model.cpp
@@ -82,7 +82,7 @@ FullVectoringRobotModel::FullVectoringRobotModel(bool init_with_rosparam, bool v
   gimbal_roll_origin_from_cog_.resize(rotor_num);
   setGimbalNominalAngles(std::vector<double>(0)); // for online initialize
 
-  robot_model_for_plan_ = boost::make_shared<aerial_robot_model::RobotModel>();
+  robot_model_for_plan_ = boost::make_shared<aerial_robot_model::transformable::RobotModel>();
 
   if(debug_verbose_)
     {


### PR DESCRIPTION
### What is this

There is a bug while assigning the arg to the variable `fixed_model_` while creating the instance for underactuated model.


### Details

- Forget to assign the boolean value for `fixed_model_` when creating the instance for underactuated model plugin.
- Use `aerial_robot_model::transformable::RobotModel` instead of `aerial_robot_model::RobotModel` for planning in dragon model and control processes.


