### PR TITLE
[GPS] remove "register" specifier for GPS time calculation. 

### DIFF
--- a/aerial_robot_estimation/include/aerial_robot_estimation/sensor/gps.h
+++ b/aerial_robot_estimation/include/aerial_robot_estimation/sensor/gps.h
@@ -111,7 +111,7 @@ namespace sensor_plugin
       /* utc time */
       /* https://github.com/KumarRobotics/ublox/blob/master/ublox_gps/include/ublox_gps/mkgmtime.h */
       time_t mkgmtime(struct tm * const tmp);
-      int tmcomp(register const struct tm * const  atmp, register const struct tm * const btmp);
+      int tmcomp(const struct tm * const  atmp, const struct tm * const btmp);
     };
 };
 

--- a/aerial_robot_estimation/src/sensor/gps.cpp
+++ b/aerial_robot_estimation/src/sensor/gps.cpp
@@ -482,9 +482,9 @@ namespace sensor_plugin
 
   time_t Gps::mkgmtime(struct tm * const tmp)
   {
-    register int            dir;
-    register int            bits;
-    register int            saved_seconds;
+    int            dir;
+    int            bits;
+    int            saved_seconds;
     time_t              t;
     struct tm           yourtm, *mytm;
 
@@ -531,9 +531,9 @@ namespace sensor_plugin
     return t;
   }
 
-  int Gps::tmcomp(register const struct tm * const  atmp, register const struct tm * const btmp)
+  int Gps::tmcomp(const struct tm * const  atmp, const struct tm * const btmp)
   {
-    register int    result;
+    int    result;
 
     if ((result = (atmp->tm_year - btmp->tm_year)) == 0 &&
         (result = (atmp->tm_mon - btmp->tm_mon)) == 0 &&


### PR DESCRIPTION
### What is this

"register" specifier is depreacated, and is not allowed in c++17.

### Details

"register": https://www.ibm.com/docs/en/zos/2.2.0?topic=specifiers-register-storage-class-specifier

Besides,  the calculation of GPS time conversion is light enough, thus register storage should be unnecessary.