### PR TITLE
[CMake] using C++17 for related packages

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -59,6 +59,16 @@ if [ ${ROS_DISTRO} = 'kinetic' ]; then
     wget https://raw.githubusercontent.com/osrf/gazebo_models/master/ground_plane/model.config -P ${path}
 fi
 
+if [[ "$ROS_DISTRO" = "kinetic" ]]; then
+    # to use c++17
+    sudo apt-get install -y software-properties-common
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+    sudo apt update
+    sudo apt install -y g++-7
+    export CXX='g++-7'
+    export CC='gcc-7'
+fi
+
 # Build
 catkin config --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 catkin build -p1 -j1 --no-status

--- a/aerial_robot_base/CMakeLists.txt
+++ b/aerial_robot_base/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_python_setup()
 
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++17)
 
 catkin_package(
   INCLUDE_DIRS include

--- a/aerial_robot_control/CMakeLists.txt
+++ b/aerial_robot_control/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(aerial_robot_control)
 
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 find_package(catkin REQUIRED COMPONENTS
   aerial_robot_estimation

--- a/aerial_robot_estimation/CMakeLists.txt
+++ b/aerial_robot_estimation/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(aerial_robot_estimation)
 
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++17)
 
 find_package(catkin REQUIRED COMPONENTS
   aerial_robot_model

--- a/aerial_robot_kinetic.rosinstall
+++ b/aerial_robot_kinetic.rosinstall
@@ -2,7 +2,7 @@
 - git:
     local-name: aerial_robot_3rdparty
     uri: https://github.com/JSKAerialRobot/aerial_robot_3rdparty.git
-    version: fb963df
+    version: b10f5bf
 
 # kalman filter
 - git:

--- a/aerial_robot_melodic.rosinstall
+++ b/aerial_robot_melodic.rosinstall
@@ -2,7 +2,7 @@
 - git:
     local-name: aerial_robot_3rdparty
     uri: https://github.com/JSKAerialRobot/aerial_robot_3rdparty.git
-    version: fb963df
+    version: b10f5bf
 
 # kalman filter
 - git:

--- a/aerial_robot_model/CMakeLists.txt
+++ b/aerial_robot_model/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(aerial_robot_model)
 
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++17)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/aerial_robot_noetic.rosinstall
+++ b/aerial_robot_noetic.rosinstall
@@ -2,7 +2,7 @@
 - git:
     local-name: aerial_robot_3rdparty
     uri: https://github.com/JSKAerialRobot/aerial_robot_3rdparty.git
-    version: fb963df
+    version: b10f5bf
 
 # kalman filter
 - git:

--- a/aerial_robot_simulation/CMakeLists.txt
+++ b/aerial_robot_simulation/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(aerial_robot_simulation)
 
-add_compile_options(-std=c++11 ${GAZEBO_CXX_FLAGS})
+add_compile_options(-std=c++17)
 
 find_package(catkin REQUIRED COMPONENTS
   aerial_robot_base

--- a/robots/dragon/CMakeLists.txt
+++ b/robots/dragon/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(dragon)
 
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++17)
 
 find_package(catkin REQUIRED COMPONENTS
   aerial_robot_control

--- a/robots/hydrus/CMakeLists.txt
+++ b/robots/hydrus/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(hydrus)
 
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++17)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp

--- a/robots/hydrus_xi/CMakeLists.txt
+++ b/robots/hydrus_xi/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(hydrus_xi)
 
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++17)
 
 find_package(catkin REQUIRED COMPONENTS
   aerial_robot_base


### PR DESCRIPTION
### What is this

Since C++17 is quite standard recently, we are going to update CMakeLists.txt in all related pakages.

### Details

- For ubuntu xenial, we manually install `g++-7` to use C++17. Please check https://github.com/tongtybj/aerial_robot/blob/c12acebe8a7453efc47700a9a844499e7e586502/.travis.sh#L62-L70
- Related work: https://github.com/jsk-ros-pkg/jsk_aerial_robot/pull/573
