### PR TITLE
[Navigation][Land] refactor the landing convergence condition 

### DIFF
--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -817,7 +817,7 @@ void BaseNavigator::update()
                 ROS_INFO("expected land height: %f (current height: %f), velocity: %f ", land_height_, curr_pos.z(), vel);
 
                 if (fabs(delta) < land_pos_convergent_thresh_ &&
-                    fabs(vel) < land_vel_convergent_thresh_)
+                    vel > -land_vel_convergent_thresh_)
                   {
                     ROS_INFO("\n \n ======================  \n Land !!! \n ====================== \n");
                     ROS_INFO("Start disarming motors");
@@ -1041,13 +1041,13 @@ void BaseNavigator::rosParamInit()
   getParam<double>(nh, "takeoff_height", takeoff_height_, 0.0);
   getParam<double>(nh, "land_descend_vel",land_descend_vel_, -0.3);
   getParam<double>(nh, "hover_convergent_duration", hover_convergent_duration_, 1.0);
-  getParam<double>(nh, "land_check_duration", land_check_duration_, 1.0);
+  getParam<double>(nh, "land_check_duration", land_check_duration_, 0.5);
   getParam<double>(nh, "trajectory_reset_duration", trajectory_reset_duration_, 0.5);
   getParam<double>(nh, "teleop_reset_duration", teleop_reset_duration_, 0.5);
   getParam<double>(nh, "z_convergent_thresh", z_convergent_thresh_, 0.05);
   getParam<double>(nh, "xy_convergent_thresh", xy_convergent_thresh_, 0.15);
   getParam<double>(nh, "land_pos_convergent_thresh", land_pos_convergent_thresh_, 0.02);
-  getParam<double>(nh, "land_vel_convergent_thresh", land_vel_convergent_thresh_, 0.01);
+  getParam<double>(nh, "land_vel_convergent_thresh", land_vel_convergent_thresh_, 0.05);
 
   //*** trajectory
   getParam<double>(nh, "trajectory_mean_vel", trajectory_mean_vel_, 0.5);


### PR DESCRIPTION
### What is this

Imrpove the landing convergence condition for faster motor disarming.

### Details

- allow the positive landing velocity in final landing convergence check 
- make the default `land_vel_convergent_thresh` larger
- make the default `land_check_duration` shorter

