### PR TITLE
[Control] enable to compensate gravity term for altitude control

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/control/base/pose_linear_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/control/base/pose_linear_controller.h
@@ -81,6 +81,7 @@ namespace aerial_robot_control
     double landing_err_z_;
     double safe_landing_height_;
     double force_landing_descending_rate_;
+    bool compensate_gravity_;
 
     tf::Vector3 pos_, target_pos_;
     tf::Vector3 vel_, target_vel_;

--- a/aerial_robot_control/src/control/base/pose_linear_controller.cpp
+++ b/aerial_robot_control/src/control/base/pose_linear_controller.cpp
@@ -140,6 +140,7 @@ namespace aerial_robot_control
 
     /* z */
     loadParam(z_nh);
+    getParam<bool>(z_nh, "compensate_gravity", compensate_gravity_, false);
     pid_controllers_.push_back(PID("z", p_gain, i_gain, d_gain, limit_sum, limit_p, limit_i, limit_d, limit_err_p, limit_err_i, limit_err_d));
     pid_reconf_servers_.push_back(boost::make_shared<PidControlDynamicConfig>(z_nh));
     pid_reconf_servers_.back()->setCallback(boost::bind(&PoseLinearController::cfgPidCallback, this, _1, _2, std::vector<int>(1, Z)));
@@ -253,9 +254,9 @@ namespace aerial_robot_control
         target_acc_.setZ(0);
       }
 
-    pid_controllers_.at(Z).update(err_z, du_z, err_v_z, target_acc_.z());
+    double gravity_term = compensate_gravity_?robot_model_->getGravity3d().z():0;
 
-    if(pid_controllers_.at(Z).getErrI() < 0) pid_controllers_.at(Z).setErrI(0);
+    pid_controllers_.at(Z).update(err_z, du_z, err_v_z, target_acc_.z() + gravity_term);
 
     if(navigator_->getForceLandingFlag())
       {

--- a/aerial_robot_control/src/control/under_actuated_lqi_controller.cpp
+++ b/aerial_robot_control/src/control/under_actuated_lqi_controller.cpp
@@ -186,6 +186,7 @@ void UnderActuatedLQIController::controlCore()
   // feed-forward term for z
   Eigen::MatrixXd q_mat_inv = getQInv();
   double ff_acc_z = navigator_->getTargetAcc().z();
+  if(compensate_gravity_) ff_acc_z += robot_model_->getGravity3d().z();
   Eigen::VectorXd ff_term = q_mat_inv.col(0) * ff_acc_z;
   target_thrust_z_term += ff_term;
 

--- a/robots/mini_quadrotor/config/FlightControl.yaml
+++ b/robots/mini_quadrotor/config/FlightControl.yaml
@@ -21,6 +21,7 @@ controller:
     limit_d: 20 # m / s^2
     landing_err_z: -0.2
     force_landing_descending_rate: -0.6
+    compensate_gravity: true
 
   yaw:
     limit_sum: 6.0 # N for clamping thrust force


### PR DESCRIPTION
### What is this

Add a flag to automatically compensate the gravity term for z axis control 

### Details

- Currently system use the I term to compensate the gravity term, which results in a slow start. We introduce a new flag to automatically compensate this term.

### TODO

- [ ]  Current takeoff procedure cause the overshooting in z axis if we enable the gravity compensation. This is because the increase of I control term during takeoff procedure. We may also need to plan a trajectory for takeoff procedure. 

