### PR TITLE
[navigation] failsafe for high input voltage

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
+++ b/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
@@ -336,6 +336,7 @@ namespace aerial_robot_navigation
     /* battery info */
     double low_voltage_thre_;
     bool low_voltage_flag_;
+    bool high_voltage_flag_;
     int bat_cell_;
     double bat_resistance_;
     double bat_resistance_voltage_rate_;

--- a/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
+++ b/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
@@ -336,6 +336,7 @@ namespace aerial_robot_navigation
     /* battery info */
     double low_voltage_thre_;
     bool low_voltage_flag_;
+    double high_voltage_cell_thre_;
     bool high_voltage_flag_;
     int bat_cell_;
     double bat_resistance_;

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -126,7 +126,7 @@ void BaseNavigator::batteryCheckCallback(const std_msgs::Float32ConstPtr &msg)
   else
     low_voltage_flag_  = false;
 
-  if(input_cell - bat_cell_ > 1.0)
+  if(input_cell - bat_cell_ > high_voltage_cell_thre_)
     {
       high_voltage_flag_ = true;
     }
@@ -1095,6 +1095,7 @@ void BaseNavigator::rosParamInit()
   ros::NodeHandle bat_nh(nh_, "bat_info");
   getParam<int>(bat_nh, "bat_cell", bat_cell_, 0); // Lipo battery cell
   getParam<double>(bat_nh, "low_voltage_thre", low_voltage_thre_, 0.1); // Lipo battery cell
+  getParam<double>(bat_nh, "high_voltage_cell_thre", high_voltage_cell_thre_, 1.0);
   getParam<double>(bat_nh, "bat_resistance", bat_resistance_, 0.0); //Battery internal resistance
   getParam<double>(bat_nh, "bat_resistance_voltage_rate", bat_resistance_voltage_rate_, 0.0); //Battery internal resistance_voltage_rate
   getParam<double>(bat_nh, "hovering_current", hovering_current_, 0.0); // current at hovering state


### PR DESCRIPTION
### What is this
failsafe for high input voltage

### Details
If input voltage is higher than nominal voltage by threshold, robot can not arm on.
Threshold can be set by rosparam

### TODO
- [x] check with real machine
