### PR TITLE
add dshot telemetry support for motor_test

### DIFF
--- a/aerial_robot_nerve/motor_test/CMakeLists.txt
+++ b/aerial_robot_nerve/motor_test/CMakeLists.txt
@@ -9,12 +9,13 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
   geometry_msgs
   takasako_sps
+  spinal
 )
 
 find_package(Boost REQUIRED COMPONENTS system)
 
 catkin_package(
-  CATKIN_DEPENDS roscpp std_msgs std_srvs geometry_msgs takasako_sps
+  CATKIN_DEPENDS roscpp std_msgs std_srvs geometry_msgs takasako_sps spinal
 )
 
 include_directories(

--- a/aerial_robot_nerve/motor_test/launch/test.launch
+++ b/aerial_robot_nerve/motor_test/launch/test.launch
@@ -9,6 +9,8 @@
   <!-- parameters for oneshot -->
   <arg name="raise_duration" default="2.0" />
   <arg name="brake_duration" default="4.0" />
+  <arg name="has_dshot_telemetry" default="false" />
+
   <arg name="force_sensor" default="CFS034CA301U" /> <!-- other sensor: PFS055YA501U6 -->
 
   <node name="power_node"  pkg="takasako_sps" type="scpi_tcp_client_node" output="screen" />
@@ -17,10 +19,10 @@
     <rosparam file="$(find cfs_sensor)/config/$(arg force_sensor).yaml" command="load" />
   </node>
 
-  <include file="$(find rosserial_server)/launch/serial.launch" >
-    <arg name="port" value="/dev/ttyUSB0" />
-    <arg name="baud" value="921600" />
-  </include>
+<!--  <include file="$(find rosserial_server)/launch/serial.launch" >-->
+<!--    <arg name="port" value="/dev/ttyUSB0" />-->
+<!--    <arg name="baud" value="921600" />-->
+<!--  </include>-->
 
   <node name="motor_test_node" pkg="motor_test" type="motor_test_node"  output="screen">
     <param name="force_sensor_sub_name" value="/cfs/data" />
@@ -33,5 +35,6 @@
     <param name="max_pwm_value" value="$(arg max_pwm_value)" />
     <param name="raise_duration" value="$(arg raise_duration)" />
     <param name="brake_duration" value="$(arg brake_duration)" />
+    <param name="has_dshot_telemetry" value="$(arg has_dshot_telemetry)" />
   </node>
 </launch>

--- a/aerial_robot_nerve/motor_test/package.xml
+++ b/aerial_robot_nerve/motor_test/package.xml
@@ -14,11 +14,13 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>takasako_sps</build_depend>
+  <build_depend>spinal</build_depend>
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
   <run_depend>takasako_sps</run_depend>
+  <run_depend>spinal</run_depend>
 
 </package>


### PR DESCRIPTION
### What is this

Add a feature to motor_test, which can record dshot telemetry data now. Tested using beetle_art.

### Details

**Example Usage**:

`roslaunch motor_test test.launch force_sensor:=PFS055YA501U6 min_pwm_value:=1000 max_pwm_value:=1100 pwm_incremental_value:=50 has_dshot_telemetry:=true`

Note that if you are using an external spinal to test the motor, please uncomment these code in test.launch:

```
<!--  <include file="$(find rosserial_server)/launch/serial.launch" >-->
<!--    <arg name="port" value="/dev/ttyUSB0" />-->
<!--    <arg name="baud" value="921600" />-->
<!--  </include>-->
```