### PR TITLE
[Mocap] improve the launch parameter

### DIFF
--- a/aerial_robot_base/launch/external_module/mocap.launch
+++ b/aerial_robot_base/launch/external_module/mocap.launch
@@ -6,8 +6,7 @@
     type="mocap_node"
     name="mocap_node"
     respawn="false"
-    launch-prefix=""
-    required="true">
+    launch-prefix="">
     <rosparam subst_value="true">
       rigid_bodies:
          '$(arg robot_id)':


### PR DESCRIPTION
### What is this

Remove the "required" flag in the launch flie to allow the onboard-sensor-only flight
