### PR TITLE
[Package.xml] Resolve dependency to other package

### DIFF
--- a/aerial_robot_nerve/spinal/package.xml
+++ b/aerial_robot_nerve/spinal/package.xml
@@ -23,6 +23,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>rosserial_client</run_depend>
   <run_depend>rosserial_server</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>rqt_gui_py</run_depend>

--- a/robots/dragon/package.xml
+++ b/robots/dragon/package.xml
@@ -17,6 +17,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>hydrus</build_depend>
   <build_depend>mujoco_ros_control</build_depend>
+  <build_depend>nlopt</build_depend>
   <build_depend>pluginlib</build_depend>
 
   <run_depend>aerial_robot_control</run_depend>
@@ -27,6 +28,7 @@
   <run_depend>aerial_robot_base</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>hydrus</run_depend>
+  <run_depend>nlopt</run_depend>
   <run_depend>pluginlib</run_depend>
 
   <test_depend>rostest</test_depend>

--- a/robots/hydrus_xi/package.xml
+++ b/robots/hydrus_xi/package.xml
@@ -12,6 +12,8 @@
   <depend>angles</depend>
   <depend>hydrus</depend>
   <depend>mujoco_ros_control</depend>
+  <depend>nlopt</depend>
+  <depend>osqp-eigen</depend>
   <depend>roscpp</depend>
 
   <exec_depend>aerial_robot_base</exec_depend>


### PR DESCRIPTION
### What is this
Fixed bug when building  each package independently.

### Details
- spinal
  - should run_depend on `rosserial_client`.  
    - https://github.com/jsk-ros-pkg/jsk_aerial_robot/blob/master/aerial_robot_nerve/spinal/scripts/make_libraries.py#L45
- hydrus_xi
  - should depend on nlopt and osqp-eigen
    - https://github.com/jsk-ros-pkg/jsk_aerial_robot/blob/master/robots/hydrus_xi/CMakeLists.txt#L13-L14
- dragon
  - should depend on nlopt 
    - https://github.com/jsk-ros-pkg/jsk_aerial_robot/blob/master/robots/dragon/CMakeLists.txt#L22
