### PR TITLE
[Spinal][Communication][WIP] switch to ETH mode

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7/Inc/main.h
+++ b/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7/Inc/main.h
@@ -47,7 +47,7 @@ extern "C" {
 
 /* Exported macro ------------------------------------------------------------*/
 /* USER CODE BEGIN EM */
-// #define USE_ETH // comment out if we do not have eth
+#define USE_ETH // comment out if we do not have eth
 /* USER CODE END EM */
 
 void HAL_TIM_MspPostInit(TIM_HandleTypeDef *htim);

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/state_estimate/attitude/attitude_estimate.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/state_estimate/attitude/attitude_estimate.h
@@ -238,7 +238,7 @@ public:
   inline const ap::Vector3f getSmoothAngular(uint8_t frame) { return estimator_->getSmoothAngular(frame); }
   inline const ap::Matrix3f getDesiredCoord()  { return estimator_->getDesiredCoord(); }
 
-  static const uint8_t IMU_PUB_INTERVAL = 5; //10-> 100Hz, 2 -> 500Hz
+  static const uint8_t IMU_PUB_INTERVAL = 2; //10-> 100Hz, 2 -> 500Hz
   static const uint8_t ATTITUDE_PUB_INTERVAL = 100; //100 -> 10Hz
 
 private:


### PR DESCRIPTION
### What is this

Manually switch to ETH mode for communication between PC to Spinal.
Usage: 
```bash
$ roslaunch spinal bridge.launch mode:=udp
```

### Details

- Currently we have to switch to ETH mode manually: https://github.com/jsk-ros-pkg/jsk_aerial_robot/compare/master...tongtybj:PR/feature/spinal/ETH_mode?expand=1#diff-aa75957129e9d66893f6dce24475bfaf9e6a7e941a5e3cbb2ecad45170cd69b5R50
- It is possible to publish the imu topic with faster rate (e.g., 500Hz): https://github.com/jsk-ros-pkg/jsk_aerial_robot/compare/master...tongtybj:PR/feature/spinal/ETH_mode?expand=1#diff-39dac9e38e440c9379ca2db26aa1ac489801d3476b73c5e9de2fbb30164036c1R241
- Setting of the ETH connection  by `$ nmtui`. You can also refer to https://github.com/jsk-ros-pkg/jsk_aerial_robot/tree/master/aerial_robot_nerve/stm32h7_nucleo#usage 
  ![Screenshot from 2024-06-15 11-43-26](https://github.com/jsk-ros-pkg/jsk_aerial_robot/assets/3666095/7d69f310-5f98-4e4c-8386-8bb9715fcaa4)
