### PR TITLE
[PR] [Simulation] add ESC_Telemetry

### DIFF
--- a/aerial_robot_nerve/spinal/msg/ESCTelemetry.msg
+++ b/aerial_robot_nerve/spinal/msg/ESCTelemetry.msg
@@ -1,0 +1,8 @@
+# check the KISS protocol for details: https://brushlesswhoop.com/dshot-and-bidirectional-dshot/
+
+int8 temperature  # 1 degree
+uint16 voltage  # 1000 = 10.00V
+uint16 current  # 1000 = 10.00A
+uint16 consumption  # 1mAh
+uint32 rpm  # 1 rpm
+uint8 crc_error  # calculated crc - received crc

--- a/aerial_robot_nerve/spinal/msg/ESCTelemetryArray.msg
+++ b/aerial_robot_nerve/spinal/msg/ESCTelemetryArray.msg
@@ -1,0 +1,6 @@
+time stamp
+# spinal/ESCTelemetry[] esc_telemetry_array
+spinal/ESCTelemetry esc_telemetry_1
+spinal/ESCTelemetry esc_telemetry_2
+spinal/ESCTelemetry esc_telemetry_3
+spinal/ESCTelemetry esc_telemetry_4

--- a/aerial_robot_simulation/include/aerial_robot_simulation/aerial_robot_hw_sim.h
+++ b/aerial_robot_simulation/include/aerial_robot_simulation/aerial_robot_hw_sim.h
@@ -49,6 +49,7 @@
 #include <gazebo/sensors/MagnetometerSensor.hh>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TwistStamped.h>
+#include "spinal/ESCTelemetryArray.h"
 #include <kdl/tree.hpp>
 #include <kdl_parser/kdl_parser.hpp>
 #include <nav_msgs/Odometry.h>
@@ -100,8 +101,10 @@ protected:
   ros::Subscriber sim_vel_sub_, sim_pos_sub_;
   ros::Publisher ground_truth_pub_;
   ros::Publisher mocap_pub_;
+  ros::Publisher esc_telem_pub_;
   double ground_truth_pub_rate_;
   double mocap_pub_rate_;
+  double esc_telem_pub_rate_;
 
   double mocap_rot_noise_, mocap_pos_noise_;
   double ground_truth_pos_noise_, ground_truth_vel_noise_, ground_truth_rot_noise_, ground_truth_angular_noise_;
@@ -112,7 +115,7 @@ protected:
   geometry_msgs::TwistStamped cmd_vel_;
   geometry_msgs::PoseStamped cmd_pos_;
 
-  ros::Time last_ground_truth_time_, last_mocap_time_;
+  ros::Time last_ground_truth_time_, last_mocap_time_, last_esc_telem_time_;
 
   void cmdVelCallback(const geometry_msgs::TwistStampedConstPtr& cmd_vel)
   {

--- a/aerial_robot_simulation/include/aerial_robot_simulation/rotor_handle.h
+++ b/aerial_robot_simulation/include/aerial_robot_simulation/rotor_handle.h
@@ -77,7 +77,7 @@ namespace hardware_interface
 
       motor_nh.param("rotor_force_noise", rotor_force_noise_, 0.0); // N
       motor_nh.param("dual_rotor_moment_noise", dual_rotor_moment_noise_, 0.0);
-      motor_nh.param("speed_rate", speed_rate_, 1.0); // rad/s/N , this is a virtual linear rate of speed-f
+      motor_nh.param("krpm_rate", krpm_rate_, 0.1); // (kRPM)^2/N , this is a virtual linear rate of speed-f
     }
 
     inline std::string getName() const {return name_;}
@@ -103,9 +103,14 @@ namespace hardware_interface
     }
     inline void setCommand(double command); //no implement here
 
+    inline int getRPM() const
+    {
+      return (int)(sqrt(*force_ * krpm_rate_) * 1000);
+    }
+
     inline double getSpeed() const
     {
-      return *force_ * speed_rate_;
+      return getRPM() * 2 * M_PI / 60;
     }
 
   private:
@@ -115,7 +120,7 @@ namespace hardware_interface
     double f_pwm_rate_;
     double f_pwm_offset_;
     double m_f_rate_;
-    double speed_rate_;
+    double krpm_rate_;
     double pwm_rate_;
     double max_pwm_;
 

--- a/aerial_robot_simulation/include/aerial_robot_simulation/rotor_handle.h
+++ b/aerial_robot_simulation/include/aerial_robot_simulation/rotor_handle.h
@@ -77,6 +77,7 @@ namespace hardware_interface
 
       motor_nh.param("rotor_force_noise", rotor_force_noise_, 0.0); // N
       motor_nh.param("dual_rotor_moment_noise", dual_rotor_moment_noise_, 0.0);
+      motor_nh.param("speed_rate", speed_rate_, 1.0); // rad/s/N , this is a virtual linear rate of speed-f
       motor_nh.param("krpm_rate", krpm_rate_, 0.1); // (kRPM)^2/N , this is a virtual linear rate of speed-f
     }
 
@@ -110,7 +111,7 @@ namespace hardware_interface
 
     inline double getSpeed() const
     {
-      return getRPM() * 2 * M_PI / 60;
+      return *force_ * speed_rate_;
     }
 
   private:
@@ -120,6 +121,7 @@ namespace hardware_interface
     double f_pwm_rate_;
     double f_pwm_offset_;
     double m_f_rate_;
+    double speed_rate_;
     double krpm_rate_;
     double pwm_rate_;
     double max_pwm_;


### PR DESCRIPTION
### What is this

Our real-world system has (partly, mainly beetle) supported ESC telemetry, but the simulation does not support. Thus, this PR adds a publisher and two msgs to pub the ESC data.

### Details

Add a "krpm_rate" to yaml config with (kRPM)^2/N unit.

I find the original equation for rotor speed is "force_ * speed_rate_", which is incorrect, since the thrust is proportional to the **square** of the motor speed. However, when I change it to the correct equation, the robot may diverge in simulation and I don't know why.

Hence, I add an additional topic to convert the thrust directly to RPM.

### TODO

- [ ] Currently, ESC Telemetry msg is unable to contain any number of motors. Need to change this msg in the future.
- [ ] The ESC Telemetry contains: temperature, voltage, current, consumption, rpm, and crc_error, which might be too many and require too much communication bandwidth. In the future, we may only need rpm for high-frequency bidirectional dshot.