### PR TITLE
[base][mocap]: add an option "enable_optitrack: true". 

### DIFF
--- a/aerial_robot_base/launch/external_module/mocap.launch
+++ b/aerial_robot_base/launch/external_module/mocap.launch
@@ -15,6 +15,7 @@
                child_frame_id: baselink
                parent_frame_id: world
       optitrack_config:
+         enable_optitrack: true
          multicast_address: 239.255.42.99
          command_port: 1510
          data_port: 1511


### PR DESCRIPTION
If this option is not set, the first connection can be made. But once you shutdown this connection, maintain roscore in one computer, and try to do another "roslaunch aerial_robot_base mocap.launch", the connection always fails.

Add this option can fix the problem. Tested in 0066.