### PR TITLE
[Navigation][Trajectory] solve the discontinued problem of yaw rotation

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/trajectory/trajectory_reference/polynomial_trajectory.hpp
+++ b/aerial_robot_control/include/aerial_robot_control/trajectory/trajectory_reference/polynomial_trajectory.hpp
@@ -57,6 +57,7 @@ class PolynomialTrajectory : public ReferenceBase {
   PolyType y_;
   PolyType z_;
   PolyType yaw_;
+  QuadState prev_constraint_;
 
   std::vector<QuadState> states_;
 

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -1002,7 +1002,10 @@ void BaseNavigator::generateNewTrajectory(geometry_msgs::PoseStamped pose)
     }
 
   double du_tran = (end_state.p - start_state.p).norm() / trajectory_mean_vel_;
-  double du_rot = fabs(end_state.getYaw() - start_state.getYaw()) / trajectory_mean_yaw_rate_;
+  double delta_yaw = end_state.getYaw() - start_state.getYaw();
+  if (delta_yaw > M_PI) delta_yaw -= 2 * M_PI;
+  if (delta_yaw < -M_PI) delta_yaw += 2 * M_PI;
+  double du_rot = fabs(delta_yaw) / trajectory_mean_yaw_rate_;
   double du = std::max(du_tran, trajectory_min_du_);
   if (!enable_latch_yaw_trajectory_)
     {


### PR DESCRIPTION
### What is this

The yaw angle has the discontinued problem around PI. This PR solve the wrong rotation path in trajectory generation, that is, the trajectory must choose the shortest path. 

### Details

This is achieved by checking diff angle with previous yaw angle, and add an offset to remove a big gap 

```
if (diff > M_PI) yaw_angle -= 2 * M_PI;
if (diff < -M_PI) yaw_angle += 2 * M_PI;
```
