### PR TITLE
[Neuron][Servo][Initialize] introduce a new variable to check the connection between spinal and neuron

### DIFF
--- a/aerial_robot_nerve/neuron/neuronlib/Initializer/initializer.cpp
+++ b/aerial_robot_nerve/neuron/neuronlib/Initializer/initializer.cpp
@@ -62,6 +62,7 @@ void Initializer::receiveDataCallback(uint8_t message_id, uint32_t DLC, uint8_t*
 	case CAN::MESSAGEID_RECEIVE_INITIAL_CONFIG_REQUEST:
 	{
 		sendBoardConfig();
+		servo_.setConnect(true);
 	}
 	break;
 	case CAN::MESSAGEID_RECEIVE_BOARD_CONFIG_REQUEST:

--- a/aerial_robot_nerve/neuron/neuronlib/Servo/servo.cpp
+++ b/aerial_robot_nerve/neuron/neuronlib/Servo/servo.cpp
@@ -11,6 +11,7 @@
 void Servo::init(UART_HandleTypeDef* huart, I2C_HandleTypeDef* hi2c, osMutexId* mutex = NULL)
 {
   servo_handler_.init(huart, hi2c, mutex);
+  connect_ = false;
 }
 
 void Servo::update()
@@ -35,6 +36,8 @@ void Servo::sendData()
 
 void Servo::receiveDataCallback(uint8_t message_id, uint32_t DLC, uint8_t* data)
 {
+	if (!connect_) return;
+
 	switch (message_id) {
 		case CAN::MESSAGEID_RECEIVE_SERVO_ANGLE:
 		{

--- a/aerial_robot_nerve/neuron/neuronlib/Servo/servo.h
+++ b/aerial_robot_nerve/neuron/neuronlib/Servo/servo.h
@@ -24,6 +24,9 @@ public:
 	void sendData() override;
 	void receiveDataCallback(uint8_t message_id, uint32_t DLC, uint8_t* data) override;
 
+	bool getConnect() {return connect_;}
+	void setConnect(bool connect) {connect_ = connect;}
+
 private:
 	struct CANServoData{
 		int16_t angle;
@@ -35,6 +38,7 @@ private:
 		:angle(angle), temperature(temperature), moving(moving), current(current), error(error){}
 	};
 
+	bool connect_;
 	DynamixelSerial servo_handler_;
 	friend class Initializer;
 };


### PR DESCRIPTION
### What is this

Do not accept any message from spinal, if neuron has not sent the initalize information to spinal.
This can avoid a corner case of the unexpected behavior of servo after updating the firmware of neuron while spinal and neurons are already connected by CAN.

### Details

- This is achieved by introducing a new variable `connect_`
- Neuron servo instance never accept any message from spinal via CAN if `connect_` is false
- `connect_` can be true only after neuron has sent the necessary information to spinal.

