### PR TITLE
[aerial_model] print inertia when launching

### DIFF
--- a/aerial_robot_model/src/model/base_model/robot_model.cpp
+++ b/aerial_robot_model/src/model/base_model/robot_model.cpp
@@ -363,6 +363,9 @@ namespace aerial_robot_model {
     ROS_INFO_STREAM_ONCE("[aerial_robot_model] robot mass is " << mass_);
 
     setInertia((cog.Inverse() * link_inertia).getRotationalInertia());
+    Eigen::Matrix3d print_inertia = getInertia<Eigen::Matrix3d>();
+    ROS_INFO_STREAM_ONCE("[aerial_robot_model] robot inertia is \n" << print_inertia);
+
     setCog2Baselink(cog.Inverse() * f_baselink);
 
     /* thrust point based on COG */


### PR DESCRIPTION
### What is this

Show Inertia when launching each quadrotor

### Details
In the case of mini_quadrotor, inertia is printed like ... ![show_inertia](https://github.com/user-attachments/assets/1753e12b-b137-4518-a51b-2dddc1e4d7c7)