### PR TITLE
[Neuron][Servo] fix bug due to #636

### DIFF
--- a/aerial_robot_nerve/neuron/neuronlib/Servo/Dynamixel/dynamixel_serial.cpp
+++ b/aerial_robot_nerve/neuron/neuronlib/Servo/Dynamixel/dynamixel_serial.cpp
@@ -273,20 +273,9 @@ void DynamixelSerial::update()
       instruction_buffer_.push(std::make_pair(INST_GET_HARDWARE_ERROR_STATUS, 0));
     }
 
-    // check the latest error status with original rule
+    // check the latest error status
     for (unsigned int i = 0; i < servo_num_; i++) {
       if (servo_[i].hardware_error_status_ != 0) {
-
-        // ingnore overload error for current based position control
-        if (servo_[i].hardware_error_status_ == (1 << OVERLOAD_ERROR)) {
-          if (servo_[i].operating_mode_ == CURRENT_BASE_POSITION_CONTROL_MODE) {
-            if (servo_[i].goal_current_ < servo_[i].current_limit_) {
-              servo_[i].force_servo_off_ = false;
-              continue;
-            }
-          }
-        }
-
         servo_[i].force_servo_off_ = true;
 
         if (servo_[i].torque_enable_) {


### PR DESCRIPTION
### What is this

The commit of [75bd140](https://github.com/jsk-ros-pkg/jsk_aerial_robot/pull/636/commits/75bd14085b608e480dc4d9192fe5c144e4e85aac) is advanced for current master version, which is based on unmerged PR of #527. 
So I just simply revert this commit.


