### PR TITLE
[Spinal][Neuron] refactor the initialization/reinitialization process

### DIFF
--- a/aerial_robot_nerve/neuron/neuronlib/Servo/servo.cpp
+++ b/aerial_robot_nerve/neuron/neuronlib/Servo/servo.cpp
@@ -27,7 +27,7 @@ void Servo::sendData()
 			CANServoData data(static_cast<int16_t>(s.getPresentPosition()),
 							  s.present_temp_,
 							  s.moving_,
-							  s.force_servo_off_,
+							  !connect_ || s.force_servo_off_,
 							  s.present_current_,
 							  s.hardware_error_status_);
 			sendMessage(CAN::MESSAGEID_SEND_SERVO_LIST[i], m_slave_id, 8, reinterpret_cast<uint8_t*>(&data), 1);

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/CANDevice/initializer/can_initializer.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/CANDevice/initializer/can_initializer.h
@@ -18,9 +18,13 @@ class CANInitializer : public CANDevice
 {
 private:
 	std::vector<Neuron>& neuron_;
+	uint8_t reboot_id_;
+	uint32_t reboot_time_;
+
 public:
-	CANInitializer(std::vector<Neuron>& neuron):CANDevice(CAN::DEVICEID_INITIALIZER, CAN::MASTER_ID), neuron_(neuron){}
+	CANInitializer(std::vector<Neuron>& neuron):CANDevice(CAN::DEVICEID_INITIALIZER, CAN::MASTER_ID), neuron_(neuron), reboot_id_(0), reboot_time_(0){}
 	void initDevices();
+	void requestConfig(uint8_t slave_id);
 	void configDevice(const spinal::SetBoardConfig::Request& req);
 	void sendData() override;
 	void receiveDataCallback(uint8_t slave_id, uint8_t message_id, uint32_t DLC, uint8_t* data) override;

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/Spine/spine.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/Spine/spine.cpp
@@ -228,6 +228,8 @@ namespace Spine
         if (send_board_index == slave_num_) send_board_index = 0;
       }
     }
+
+    can_initializer_.sendData(); // if necessary
   }
 
   void update(void)


### PR DESCRIPTION
### What is this

Solve the corner case due to the error of servo motor connected to the neuron, which requires the force reboot of the neuron from spinal.

### Details

- Send `force_torque_off` as `true` is the neuron is not ready to connect with spinal. This is the corner case that the neuron is manually rebooted by spinal, but the neuron does not send the initial config to the spinal.
- Recall the config request from spinal to the rebooted neuron after the reboot is finish. 
