### PR TITLE
[GA][Catkin Lint] refactor the script to run catkin lint

### DIFF
--- a/.github/workflows/catkin_lint.yml
+++ b/.github/workflows/catkin_lint.yml
@@ -5,23 +5,26 @@ jobs:
     runs-on: ubuntu-latest
     name: catkin_lint
 
+    container: ubuntu:20.04
+
     steps:
       - name: Setup OS
         run: |
-          sudo apt-get update -y
-          sudo apt-get upgrade -y
+          apt-get update -y
+          apt-get upgrade -y
       - name: Setup Git
         run: |
-          sudo apt-get install -y git
+          apt-get install -y git
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: catkin lint setup
         run: |
-          sudo apt-get install -y -q python3-pip python3-wstool
-          sudo pip3 install catkin_lint rosdep
-          sudo rosdep init
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get install -y -q python3-pip python3-wstool
+          pip3 install catkin_lint rosdep
+          rosdep init
           rosdep update
       - name: catkin lint test
         run: |


### PR DESCRIPTION
### What is this

Explictly specify the distribution of ubuntu (20.04) to avoid the random failure of installation of `python3-wstool`.

### Details

- `sudo` is not required 
- `DEBIAN_FRONTEND=noninteractive` is required to avoid the unexpected wait for installation of `tzdate`

