### PR TITLE
[GA][Firmware Build] refactor the catkin build option to avoid the message generation error

### DIFF
--- a/.github/workflows/spinal_build.yml
+++ b/.github/workflows/spinal_build.yml
@@ -31,7 +31,7 @@ jobs:
           source /opt/ros/noetic/setup.bash
           cd ~/catkin_ws
           catkin config --cmake-args -Dcatkin_DIR=/opt/ros/noetic/share/catkin/cmake
-          catkin build spinal
+          catkin build -p 1 -j 1 spinal
           source devel/setup.bash
         shell: bash
 


### PR DESCRIPTION
### What is this

The ros header files for spinal `ros_lib`  are always build incorrectly, because the multiple processes (and multiple jobs) in CI cannot perform pefectly. Therefore, it is necessary to explicitly speficy the build option wtin single process and single job.

### Details

The failure of  `ros_lib` is due to the imcomplete build of the ros messages if multiple processes are allowed in CI. One of the exmaple is https://github.com/jsk-ros-pkg/jsk_aerial_robot/actions/runs/12523073205/job/35008028809#step:5:235. 
