### PR TITLE
[Estimation] stop broadcasting redundant TF with same timestamp

### DIFF
--- a/aerial_robot_estimation/src/state_estimation.cpp
+++ b/aerial_robot_estimation/src/state_estimation.cpp
@@ -84,6 +84,8 @@ void StateEstimator::initialize(ros::NodeHandle nh, ros::NodeHandle nh_private, 
 
 void StateEstimator::statePublish(const ros::TimerEvent & e)
 {
+  static ros::Time prev_pub_stamp = ros::Time(0);
+
   ros::Time imu_stamp = boost::dynamic_pointer_cast<sensor_plugin::Imu>(imu_handlers_.at(0))->getStamp();
   aerial_robot_msgs::States full_state;
   full_state.header.stamp = imu_stamp;
@@ -159,21 +161,25 @@ void StateEstimator::statePublish(const ros::TimerEvent & e)
   baselink_odom_pub_.publish(odom_state);
 
   /* TF broadcast from world frame */
-  tf::Transform root2baselink_tf;
-  const auto segments_tf = robot_model_->getSegmentsTf();
-  if(segments_tf.size() > 0) // kinemtiacs is initialized
-    tf::transformKDLToTF(segments_tf.at(robot_model_->getBaselinkName()), root2baselink_tf);
-  else
-    root2baselink_tf.setIdentity(); // not initialized
+  /* avoid the redundant timestamp which induces annoying loggings from TF server */
+  if (imu_stamp != prev_pub_stamp)
+    {
+      tf::Transform root2baselink_tf;
+      const auto segments_tf = robot_model_->getSegmentsTf();
+      if(segments_tf.size() > 0) // kinemtiacs is initialized
+        tf::transformKDLToTF(segments_tf.at(robot_model_->getBaselinkName()), root2baselink_tf);
+      else
+        root2baselink_tf.setIdentity(); // not initialized
 
-  tf::Transform world2baselink_tf;
-  tf::poseMsgToTF(odom_state.pose.pose, world2baselink_tf);
-  geometry_msgs::TransformStamped transformStamped;
-  tf::transformStampedTFToMsg(tf::StampedTransform(world2baselink_tf * root2baselink_tf.inverse(),
-                                                   imu_stamp, "world",
-                                                   tf::resolve(tf_prefix_, std::string("root"))),
-                              transformStamped);
-  br_.sendTransform(transformStamped);
+      tf::Transform world2baselink_tf;
+      tf::poseMsgToTF(odom_state.pose.pose, world2baselink_tf);
+      geometry_msgs::TransformStamped transformStamped;
+      tf::transformStampedTFToMsg(tf::StampedTransform(world2baselink_tf * root2baselink_tf.inverse(),
+                                                       imu_stamp, "world",
+                                                       tf::resolve(tf_prefix_, std::string("root"))),
+                                  transformStamped);
+      br_.sendTransform(transformStamped);
+    }
 
   /* COG */
   /* Rotation */
@@ -186,6 +192,7 @@ void StateEstimator::statePublish(const ros::TimerEvent & e)
   tf::vector3TFToMsg(getVel(Frame::COG, estimate_mode_), odom_state.twist.twist.linear);
   cog_odom_pub_.publish(odom_state);
 
+  prev_pub_stamp = imu_stamp;
 }
 
 


### PR DESCRIPTION
### What is this

Stop broadcasting TF if the timestamp is identical with the last one.

### Details

Please explain the contribution of this PR in detail.

- The TF server will generate annoying warning message if there is broadcaster that send TF with same timestamp as shown in the following image.
![image](https://github.com/user-attachments/assets/9a2c99e1-5930-4e32-b609-8bae3567af6a)

- This might happen for our system especially in simulation mode, since the TF from `world` to `root` uses the timestamp provided by IMU.