### PR TITLE
[Dragon][Naviagation] refactor the landing process

### DIFF
--- a/robots/dragon/include/dragon/dragon_navigation.h
+++ b/robots/dragon/include/dragon/dragon_navigation.h
@@ -54,8 +54,6 @@ namespace aerial_robot_navigation
 
     void update() override;
 
-    inline const bool getLandingFlag() const { return landing_flag_; }
-
   private:
     ros::Publisher curr_target_baselink_rot_pub_;
     ros::Publisher joint_control_pub_;
@@ -81,7 +79,6 @@ namespace aerial_robot_navigation
 
     /* landing process */
     bool level_flag_;
-    bool landing_flag_;
     bool servo_torque_;
 
     /* rosparam */
@@ -89,5 +86,8 @@ namespace aerial_robot_navigation
     string joints_torque_control_srv_name_, gimbals_torque_control_srv_name_;
     double baselink_rot_change_thresh_;
     double baselink_rot_pub_interval_;
+
+    // addtional state 
+    static constexpr uint8_t PRE_LAND_STATE = 0x20;
   };
 };

--- a/robots/dragon/src/control/lqi_gimbal_control.cpp
+++ b/robots/dragon/src/control/lqi_gimbal_control.cpp
@@ -225,8 +225,8 @@ void DragonLQIGimbalController::gimbalControl()
       std::cout << "gimbal force for horizontal control:"  << std::endl << f_xy << std::endl;
     }
 
-  /* external wrench compensation */
-  if(boost::dynamic_pointer_cast<aerial_robot_navigation::DragonNavigator>(navigator_)->getLandingFlag())
+  /* clear external wrench compensation */
+  if(navigator_->getNaviState() != aerial_robot_navigation::HOVER_STATE)
     {
       dragon_robot_model_->resetExternalStaticWrench(); // clear the external wrench
       extra_vectoring_force_.setZero(); // clear the extra vectoring force
@@ -321,7 +321,7 @@ bool DragonLQIGimbalController::clearExternalWrenchCallback(gazebo_msgs::BodyReq
 /* extra vectoring force  */
 void DragonLQIGimbalController::extraVectoringForceCallback(const std_msgs::Float32MultiArrayConstPtr& msg)
 {
-  if(navigator_->getNaviState() != aerial_robot_navigation::HOVER_STATE || navigator_->getForceLandingFlag() || boost::dynamic_pointer_cast<aerial_robot_navigation::DragonNavigator>(navigator_)->getLandingFlag()) return;
+  if(navigator_->getNaviState() != aerial_robot_navigation::HOVER_STATE || navigator_->getForceLandingFlag()) return;
 
   if(extra_vectoring_force_.size() != msg->data.size())
     {


### PR DESCRIPTION
### What is this

DRAGON needs to make the body level before entering the landing phase. This was achieved by using an additional flag `landing_flag`, and the flight state was temporarily back to `HOVER_STATE` to make the body level. However, this is a special phase and the robot should not receive any navigation command which would hinder the leveling motion. Therefore,  a new state called `PRE_LAND_STATE` is introduced to handle this special phase.

### Details
- remove `landing_flag` , and replace with new fligtht state `PRE_LAND_STATE`
- modify the leveling process with new fligtht state `PRE_LAND_STATE`
- modify other related control parts that depended on `landing_flag`

