### PR TITLE
[aerial_robot_estimation] same yaw direction as 326 world

### DIFF
--- a/aerial_robot_estimation/src/sensor/vo.cpp
+++ b/aerial_robot_estimation/src/sensor/vo.cpp
@@ -263,7 +263,8 @@ namespace sensor_plugin
         tf::Transform vo_bdash_f = raw_sensor_tf * sensor_tf_.inverse(); // ^{vo}H_{b}
         double r,p,y;
         vo_bdash_f.getBasis().getRPY(r,p,y);
-        vo_bdash_f.setRotation(tf::createQuaternionFromYaw(y)); // ^{vo}H_{b'}
+	/** set same yaw direction as 326 world**/
+        vo_bdash_f.setRotation(tf::createQuaternionFromYaw(y+2.4)); // ^{vo}H_{b'}
 
         /** step3: ^{w}H_{vo} = ^{w}H_{b'} * ^{b'}H_{vo} **/
         world_offset_tf_ = w_bdash_f * vo_bdash_f.inverse();


### PR DESCRIPTION
### What is this
Remake yaw direction difference to mocap system in 326 in flight by livox.

### Details
- hard code yaw direction when initialize direction in yaw
- remake ^{vo}H_{b'} direction as increase 2.4 rad

### TODO
- check if this is abailable in the flight with mocap
- remake hardcoding of the yaw direction
- can set differnt variable by different rooms from launch file

### Figs
In the quadrotor is setted in _**R** = **I**_ mocap in 326...
before: 
![body_world_difference_before](https://github.com/user-attachments/assets/ef1d41fd-3bc1-4d4b-bbcb-3d5441d19c2b)

after: 
![body_world_difference](https://github.com/user-attachments/assets/888988ed-6aa1-44e5-8600-85f431c138b3)
