### PR TITLE
[Firmware][STM32CubeIDE] remove conflicted flie main.c from the project configuration file

### DIFF
--- a/aerial_robot_nerve/neuron/neuron_f4/STM32CubeIDE/.project
+++ b/aerial_robot_nerve/neuron/neuron_f4/STM32CubeIDE/.project
@@ -73,11 +73,6 @@
 			<locationURI>$%7BPARENT-1-PROJECT_LOC%7D/Src/main.cpp</locationURI>
 		</link>
 		<link>
-			<name>Application/User/main.cpp</name>
-			<type>1</type>
-			<locationURI>$%7BPARENT-1-PROJECT_LOC%7D/Src/main.cpp</locationURI>
-		</link>
-		<link>
 			<name>Application/User/spi.c</name>
 			<type>1</type>
 			<locationURI>$%7BPARENT-1-PROJECT_LOC%7D/Src/spi.c</locationURI>

--- a/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7/STM32CubeIDE/.project
+++ b/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7/STM32CubeIDE/.project
@@ -68,11 +68,6 @@
 			<locationURI>PARENT-1-PROJECT_LOC/Src/lwip.c</locationURI>
 		</link>
 		<link>
-			<name>Application/User/main.c</name>
-			<type>1</type>
-			<locationURI>PARENT-1-PROJECT_LOC/Src/main.c</locationURI>
-		</link>
-		<link>
 			<name>Application/User/main.cpp</name>
 			<type>1</type>
 			<locationURI>$%7BPARENT-1-PROJECT_LOC%7D/Src/main.cpp</locationURI>

--- a/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7_v2/STM32CubeIDE/.project
+++ b/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7_v2/STM32CubeIDE/.project
@@ -68,11 +68,6 @@
 			<locationURI>PARENT-1-PROJECT_LOC/Src/lwip.c</locationURI>
 		</link>
 		<link>
-			<name>Application/User/main.c</name>
-			<type>1</type>
-			<locationURI>PARENT-1-PROJECT_LOC/Src/main.c</locationURI>
-		</link>
-		<link>
 			<name>Application/User/main.cpp</name>
 			<type>1</type>
 			<locationURI>$%7BPARENT-1-PROJECT_LOC%7D/Src/main.cpp</locationURI>


### PR DESCRIPTION
### What is this

Remove the conflicted `main.c` from the project config file `.project`

### Detail

The file `main.c` causes confliction, since  the build rule is based on `main.cpp` .
In the past, STM32CubeIDE generated build error if there were both `main.cpp` and `main.c`, but becomes warning message recently.
However, it is still better to remove it from the config file. 