### PR TITLE
[aerial_robot_model] add new API to get and set extra module map

### DIFF
--- a/aerial_robot_model/include/aerial_robot_model/model/aerial_robot_model.h
+++ b/aerial_robot_model/include/aerial_robot_model/model/aerial_robot_model.h
@@ -129,7 +129,7 @@ namespace aerial_robot_model {
 
     bool addExtraModule(std::string module_name, std::string parent_link_name, KDL::Frame transform, KDL::RigidBodyInertia inertia);
     bool removeExtraModule(std::string module_name);
-    std::map<std::string, KDL::Segment> getExtraModuleMap() const {return extra_module_map_;}
+    const std::map<std::string, KDL::Segment>& getExtraModuleMap() const {return extra_module_map_;}
     void setExtraModuleMap(const std::map<std::string, KDL::Segment>& map) {extra_module_map_ = map;}
 
     // statics (static thrust, joint torque)

--- a/aerial_robot_model/include/aerial_robot_model/model/aerial_robot_model.h
+++ b/aerial_robot_model/include/aerial_robot_model/model/aerial_robot_model.h
@@ -129,6 +129,8 @@ namespace aerial_robot_model {
 
     bool addExtraModule(std::string module_name, std::string parent_link_name, KDL::Frame transform, KDL::RigidBodyInertia inertia);
     bool removeExtraModule(std::string module_name);
+    std::map<std::string, KDL::Segment> getExtraModuleMap() const {return extra_module_map_;}
+    void setExtraModuleMap(const std::map<std::string, KDL::Segment>& map) {extra_module_map_ = map;}
 
     // statics (static thrust, joint torque)
     Eigen::VectorXd calcGravityWrenchOnRoot();


### PR DESCRIPTION
### What is this
Add new API to get and set extra module map.
These API is required to set exrra module map state in ROS-related model to other robot model instance (e.g. `robot_model_for_control_` in dragon)
