### PR TITLE
[GA][Firmware Build] udpate the debian list at the beginning 

### DIFF
--- a/.github/workflows/firmware_build.yml
+++ b/.github/workflows/firmware_build.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Install ROS packages with rosdep # Setup Github ws as a catkin ws
         shell: bash
         run: |
+          sudo apt-get update
           source /opt/ros/noetic/setup.bash
           rm /etc/ros/rosdep/sources.list.d/20-default.list
           sudo rosdep init


### PR DESCRIPTION
### What is this

Since the docker file for firmware build is rarely updated. The list of debian packages might be old.
So it is necessary to update the list by `apt update` at the beginning of CI

Please briefly explain the purpose and the result of this PR.

### Details

- problem:  https://github.com/jsk-ros-pkg/jsk_aerial_robot/actions/runs/12831193462/job/35807420902#step:4:123
- reason: docker file is not updated but the URL of debian package is updated. 
- solution: update the list by `apt update`