### PR TITLE
[Servo][Spinal][Neuron] send goal postion from neuron to spinal to solve the sync problem between them when using external encoder

### DIFF
--- a/aerial_robot_nerve/neuron/neuronlib/Servo/Dynamixel/dynamixel_serial.h
+++ b/aerial_robot_nerve/neuron/neuronlib/Servo/Dynamixel/dynamixel_serial.h
@@ -320,6 +320,7 @@ public:
           hardware_error_status_(0),
           torque_enable_(false),
           force_servo_off_(false),
+          send_goal_position_(false),
           first_get_pos_flag_(true)
   {}
 
@@ -349,12 +350,13 @@ public:
 	bool led_;
 	bool torque_enable_;
   	bool force_servo_off_;
+	bool send_goal_position_;
 	bool first_get_pos_flag_;
 
 	void updateHomingOffset() { homing_offset_ = calib_value_ - present_position_;}
-	void setPresentPosition(int32_t present_position) {present_position_ = present_position + internal_offset_;}
 	int32_t getPresentPosition() const {return present_position_;}
-	void setGoalPosition(int32_t goal_position) {goal_position_ = resolution_ratio_ * goal_position - internal_offset_;}
+	void setGoalPosition(int32_t goal_position) {goal_position_ = goal_position;}
+  	int32_t getInternalGoalPosition() const {return resolution_ratio_ * goal_position_ - internal_offset_;}
 	int32_t getGoalPosition() const {return goal_position_;}
 	void setGoalCurrent(int16_t goal_current) {goal_current_ = goal_current;}
 	int16_t getGoalCurrent() const { return goal_current_;}
@@ -370,7 +372,7 @@ public:
   void ping();
   HAL_StatusTypeDef read(uint8_t* data,  uint32_t timeout);
   void reboot(uint8_t servo_index);
-  void setTorque(uint8_t servo_index);
+  void setTorque(uint8_t servo_index, bool torque_enable);
   void setHomingOffset(uint8_t servo_index);
   void setRoundOffset(uint8_t servo_index, int32_t ref_value);
   void setPositionGains(uint8_t servo_index);

--- a/aerial_robot_nerve/neuron/neuronlib/Servo/servo.cpp
+++ b/aerial_robot_nerve/neuron/neuronlib/Servo/servo.cpp
@@ -59,11 +59,18 @@ void Servo::receiveDataCallback(uint8_t message_id, uint32_t DLC, uint8_t* data)
         if (sign != 0) {
           goal_pos = 0xFFFF8000 | goal_pos;
         }
-        bool valid = (((data[i * 2 + 1] >> 7) & 0x01) != 0) ? true : false;
-        if (valid) {
-          s.setGoalPosition(goal_pos);
-          s.send_goal_position_ = false;
-        }
+
+        if (!s.torque_enable_) continue;
+
+        if (s.send_goal_position_)
+          {
+            bool ack = ((data[i * 2 + 1] >> 7) & 0x01);
+            if (!ack) continue;;
+
+            s.send_goal_position_ = false;
+          }
+
+        s.setGoalPosition(goal_pos);
       }
       break;
     }

--- a/aerial_robot_nerve/neuron/neuronlib/Servo/servo.cpp
+++ b/aerial_robot_nerve/neuron/neuronlib/Servo/servo.cpp
@@ -16,59 +16,72 @@ void Servo::init(UART_HandleTypeDef* huart, I2C_HandleTypeDef* hi2c, osMutexId* 
 
 void Servo::update()
 {
-	servo_handler_.update();
+  servo_handler_.update();
 }
 
 void Servo::sendData()
 {
-	for (unsigned int i = 0; i < servo_handler_.getServoNum(); i++) {
-		const ServoData& s = servo_handler_.getServo()[i];
-		if (s.send_data_flag_ != 0) {
-			CANServoData data(static_cast<int16_t>(s.getPresentPosition()),
-							  s.present_temp_,
-							  s.moving_,
-							  !connect_ || s.force_servo_off_,
-							  s.present_current_,
-							  s.hardware_error_status_);
-			sendMessage(CAN::MESSAGEID_SEND_SERVO_LIST[i], m_slave_id, 8, reinterpret_cast<uint8_t*>(&data), 1);
-		}
-	}
+  for (unsigned int i = 0; i < servo_handler_.getServoNum(); i++) {
+    const ServoData& s = servo_handler_.getServo()[i];
+
+    if (!s.send_data_flag_) {
+      continue;
+    }
+
+    int32_t position = s.getPresentPosition();
+    if (s.send_goal_position_) {
+      position = s.getGoalPosition();
+    }
+
+    CANServoData data(static_cast<int16_t>(position),
+                      s.present_temp_,
+                      s.moving_,
+                      !connect_ || s.force_servo_off_,
+                      s.send_goal_position_,
+                      s.present_current_,
+                      s.hardware_error_status_);
+    sendMessage(CAN::MESSAGEID_SEND_SERVO_LIST[i], m_slave_id, 8, reinterpret_cast<uint8_t*>(&data), 1);
+  }
 }
 
 void Servo::receiveDataCallback(uint8_t message_id, uint32_t DLC, uint8_t* data)
 {
-	if (!connect_) return;
+  if (!connect_) return;
 
-	switch (message_id) {
-		case CAN::MESSAGEID_RECEIVE_SERVO_ANGLE:
-		{
-			for (unsigned int i = 0; i < servo_handler_.getServoNum(); i++) {
-				ServoData& s = servo_handler_.getServo()[i];
-				//convert int15 to int32
-				int sign = data[i * 2 + 1] & 0x40;
-				int32_t goal_pos = ((data[i * 2 + 1]  & 0x7F) << 8) | data[i * 2];
-				if (sign != 0) {
-					goal_pos = 0xFFFF8000 | goal_pos;
-				}
-				s.setGoalPosition(goal_pos);
-				bool torque_enable = (((data[i * 2 + 1] >> 7) & 0x01) != 0) ? true : false;
-                                if (!s.force_servo_off_) {
-                                  if (s.torque_enable_ != torque_enable) {
-                                    s.torque_enable_ = torque_enable;
-                                    servo_handler_.setTorque(i);
-                                  }
-                                }
-			}
-			break;
-		}
-		case CAN::MESSAGEID_RECEIVE_SERVO_CURRENT:
-		{
-			for (unsigned int i = 0; i < servo_handler_.getServoNum(); i++) {
-				ServoData& s = servo_handler_.getServo()[i];
-				int16_t goal_current = (int16_t)(((data[i * 2 + 1] << 8) & 0xFF00) | (data[i * 2] & 0xFF));
-				s.setGoalCurrent(goal_current);
-			}
-			break;
-		}
-	}
+  switch (message_id) {
+  case CAN::MESSAGEID_RECEIVE_SERVO_ANGLE:
+    {
+      for (unsigned int i = 0; i < servo_handler_.getServoNum(); i++) {
+        ServoData& s = servo_handler_.getServo()[i];
+        //convert int15 to int32
+        int sign = data[i * 2 + 1] & 0x40;
+        int32_t goal_pos = ((data[i * 2 + 1]  & 0x7F) << 8) | data[i * 2];
+        if (sign != 0) {
+          goal_pos = 0xFFFF8000 | goal_pos;
+        }
+        bool valid = (((data[i * 2 + 1] >> 7) & 0x01) != 0) ? true : false;
+        if (valid) {
+          s.setGoalPosition(goal_pos);
+          s.send_goal_position_ = false;
+        }
+      }
+      break;
+    }
+  case CAN::MESSAGEID_RECEIVE_SERVO_CURRENT:
+    {
+      for (unsigned int i = 0; i < servo_handler_.getServoNum(); i++) {
+        ServoData& s = servo_handler_.getServo()[i];
+        //convert int15 to int32
+        int sign = data[i * 2 + 1] & 0x40;
+        int16_t goal_current = (int16_t)((((data[i * 2 + 1] & 0x7F) << 8) & 0xFF00) | (data[i * 2] & 0xFF));
+        if (sign != 0) {
+          goal_current = 0x8000 | goal_current;
+        }
+        s.setGoalCurrent(goal_current);
+        bool torque_enable = (((data[i * 2 + 1] >> 7) & 0x01) != 0) ? true : false;
+        servo_handler_.setTorque(i, torque_enable);
+      }
+      break;
+    }
+  }
 }

--- a/aerial_robot_nerve/neuron/neuronlib/Servo/servo.h
+++ b/aerial_robot_nerve/neuron/neuronlib/Servo/servo.h
@@ -34,10 +34,10 @@ private:
 		uint8_t status;
 		int16_t current;
 		uint8_t error;
-		CANServoData(uint16_t angle, uint8_t temperature, uint8_t moving, bool force_servo_disable, int16_t current, uint8_t error)
+		CANServoData(uint16_t angle, uint8_t temperature, uint8_t moving, bool force_servo_disable, bool send_target_postion, int16_t current, uint8_t error)
 		:angle(angle), temperature(temperature), current(current), error(error)
           {
-            status = (force_servo_disable? 1 : 0) | moving << 1;
+            status = (force_servo_disable? 1 : 0) | moving << 1 | send_target_postion << 2;
           }
 	};
 

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/CANDevice/servo/can_servo.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/CANDevice/servo/can_servo.cpp
@@ -12,35 +12,45 @@ void Servo::setTorqueEnable(bool torque_enable)
   if (force_servo_off_) return;
 
   torque_enable_ = torque_enable;
+
+  if (!torque_enable_) goal_position_valid_flag_ = false;
 }
 
 void CANServo::sendData()
 {
-	uint16_t target_angle[4];
-	for (unsigned int i = 0 ; i < servo_.size(); i++) {
-		target_angle[i] = ((servo_[i].torque_enable_ ? 1 : 0) << 15) | (servo_[i].goal_position_ & 0x7FFF);
-	}
-	sendMessage(CAN::MESSAGEID_RECEIVE_SERVO_ANGLE, m_slave_id, servo_.size() * 2, reinterpret_cast<uint8_t*>(target_angle), 0);
+  uint16_t target_angle[4];
+  for (unsigned int i = 0 ; i < servo_.size(); i++) {
+    target_angle[i] = ((servo_[i].goal_position_valid_flag_ ? 1 : 0) << 15) | (servo_[i].goal_position_ & 0x7FFF);
+  }
+  sendMessage(CAN::MESSAGEID_RECEIVE_SERVO_ANGLE, m_slave_id, servo_.size() * 2, reinterpret_cast<uint8_t*>(target_angle), 0);
 
-	int16_t target_current[4];
-	for (unsigned int i = 0 ; i < servo_.size(); i++) {
-		target_current[i] = servo_[i].goal_current_;
-	}
-	sendMessage(CAN::MESSAGEID_RECEIVE_SERVO_CURRENT, m_slave_id, servo_.size() * 2, reinterpret_cast<uint8_t*>(target_current), 0);
+  uint16_t target_current[4];
+  for (unsigned int i = 0 ; i < servo_.size(); i++) {
+    target_current[i] = ((servo_[i].torque_enable_ ? 1 : 0) << 15) | (servo_[i].goal_current_ & 0x7FFF);
+  }
+  sendMessage(CAN::MESSAGEID_RECEIVE_SERVO_CURRENT, m_slave_id, servo_.size() * 2, reinterpret_cast<uint8_t*>(target_current), 0);
 
 }
 
 void CANServo::receiveDataCallback(uint8_t slave_id, uint8_t message_id, uint32_t DLC, uint8_t* data)
 {
-	CANServoData servo_data = *(reinterpret_cast<CANServoData*>(data));
-	servo_[message_id].present_position_ = servo_data.angle;
-	servo_[message_id].present_temperature_ = servo_data.temperature;
-	servo_[message_id].moving_ = (servo_data.status >> 1) & 0x01 ;
-	servo_[message_id].force_servo_off_ = ((servo_data.status & 0x01) != 0)? true: false;
-	servo_[message_id].present_current_ = servo_data.current;
-	servo_[message_id].error_ = servo_data.error;
+  CANServoData servo_data = *(reinterpret_cast<CANServoData*>(data));
+  servo_[message_id].present_temperature_ = servo_data.temperature;
+  servo_[message_id].moving_ = (servo_data.status >> 1) & 0x01;
+  servo_[message_id].force_servo_off_ = ((servo_data.status & 0x01) != 0)? true: false;
+  bool receive_target_position = (servo_data.status >> 2) & 0x01;
+  if (receive_target_position) { // tricky process to save slot
+    servo_[message_id].goal_position_ = servo_data.angle;
+    servo_[message_id].goal_position_valid_flag_ = true;
+  } else {
+    servo_[message_id].present_position_ = servo_data.angle;
+  }
 
-	if (servo_[message_id].force_servo_off_) {
-          servo_[message_id].torque_enable_ = false;
-        }
+  servo_[message_id].present_current_ = servo_data.current;
+  servo_[message_id].error_ = servo_data.error;
+
+  if (servo_[message_id].force_servo_off_) {
+    servo_[message_id].torque_enable_ = false;
+    servo_[message_id].goal_position_valid_flag_ = false;
+  }
 }

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/CANDevice/servo/can_servo.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/CANDevice/servo/can_servo.h
@@ -27,6 +27,7 @@ private:
 	uint8_t error_;
 	bool send_data_flag_;
 	bool torque_enable_;
+	bool goal_position_valid_flag_;
 	bool force_servo_off_;
 	bool external_encoder_flag_;
 	uint16_t joint_resolution_;
@@ -35,7 +36,7 @@ private:
 	friend class CANServo;
 	friend class CANInitializer;
 public:
-	Servo():torque_enable_(true) {}
+  Servo():torque_enable_(true), goal_position_valid_flag_(false) {}
 	uint8_t getId() const {return id_;}
 	uint8_t getIndex () const {return index_;}
 	uint16_t getPGain() const {return p_gain_;}

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/CANDevice/servo/can_servo.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Hydrus_Lib/CANDevice/servo/can_servo.h
@@ -27,7 +27,7 @@ private:
 	uint8_t error_;
 	bool send_data_flag_;
 	bool torque_enable_;
-	bool goal_position_valid_flag_;
+	bool goal_position_ack_;
 	bool force_servo_off_;
 	bool external_encoder_flag_;
 	uint16_t joint_resolution_;
@@ -36,7 +36,7 @@ private:
 	friend class CANServo;
 	friend class CANInitializer;
 public:
-  Servo():torque_enable_(true), goal_position_valid_flag_(false) {}
+  Servo():torque_enable_(true), goal_position_ack_(false) {}
 	uint8_t getId() const {return id_;}
 	uint8_t getIndex () const {return index_;}
 	uint16_t getPGain() const {return p_gain_;}


### PR DESCRIPTION
### What is this

update and send goal postion from neuron to spinal to handle sync problem when using external encoder.

### Details

- new goal position after the servo toruqe turning on is determined by neuron, and is sent to spinal to replace with the old goal position in it.
- the goal position and the present position share the same slot from neuron to spinal to save the limited bandwidth of CAN.
- acknowledge flag is introduced to handle the mode switch between goal poisiton sending and present position sending.
- the torque enable flag is shifted from `CAN::MESSAGEID_RECEIVE_SERVO_ANGLE` to `CAN::MESSAGEID_RECEIVE_SERVO_CURRENT`
