### PR TITLE
[CI][Architecuture] suport test on arm64 architecture

### DIFF
--- a/.github/workflows/ros_test.yml
+++ b/.github/workflows/ros_test.yml
@@ -2,18 +2,25 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
-    name: ros_build_test
     strategy:
       fail-fast: false
       matrix:
         include:
-          - ROS_DISTRO : melodic
+          - runs-on: ubuntu-latest
+            ROS_DISTRO : melodic
             DOCKER_IMAGE : ubuntu:bionic
-          - ROS_DISTRO : noetic
+          - runs-on: ubuntu-latest
+            ROS_DISTRO : noetic
             DOCKER_IMAGE : ubuntu:focal
-          - ROS_DISTRO : one
+          - runs-on: ubuntu-latest
+            ROS_DISTRO : one
             DOCKER_IMAGE : ubuntu:jammy
+          - runs-on: ubuntu-22.04-arm
+            ROS_DISTRO : noetic
+            DOCKER_IMAGE : ubuntu:focal
+    runs-on: ${{ matrix.runs-on }}
+    name: ros_build_test-${{ matrix.runs-on }}-${{ matrix.ROS_DISTRO }}
+
     steps:
       - name: Setup OS
         run: |

--- a/robots/mini_quadrotor/test/CMakeLists.txt
+++ b/robots/mini_quadrotor/test/CMakeLists.txt
@@ -8,6 +8,13 @@ execute_process(COMMAND ${LSB_RELEASE_EXEC} -c
 string(REPLACE "\t" ";" LSB_RELEASE_CODENAME_LIST ${LSB_RELEASE_CODENAME})
 list(GET LSB_RELEASE_CODENAME_LIST 1 CODENAME)
 
-if(NOT ${CODENAME} MATCHES "xenial")
+# Get the system architecture
+execute_process(COMMAND uname -m
+    OUTPUT_VARIABLE SYSTEM_ARCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Skip add_rostest if the system is running Ubuntu Xenial or on an arm64 architecture
+if(NOT ${CODENAME} MATCHES "xenial" AND NOT ${SYSTEM_ARCH} MATCHES "arm64")
   add_rostest(flight_control.test ARGS headless:=true mujoco:=true)
 endif()

--- a/robots/mini_quadrotor/test/CMakeLists.txt
+++ b/robots/mini_quadrotor/test/CMakeLists.txt
@@ -15,6 +15,6 @@ execute_process(COMMAND uname -m
 )
 
 # Skip add_rostest if the system is running Ubuntu Xenial or on an arm64 architecture
-if(NOT ${CODENAME} MATCHES "xenial" AND NOT ${SYSTEM_ARCH} MATCHES "arm64")
+if(NOT ${CODENAME} MATCHES "xenial" AND NOT ${SYSTEM_ARCH} MATCHES "aarch64")
   add_rostest(flight_control.test ARGS headless:=true mujoco:=true)
 endif()


### PR DESCRIPTION
### What is this

Add arm64 architecture in github action to enable test for arm-based computer.

### Details

- Update matrix in github action to support both x64 and arm64 archs.
- Skip mujoco-based simulation in arm64 archs.