### PR TITLE
[Feasible Control Convex] [Jacobian] refactor singularity handle with two unit vectors are almost paralell 

### DIFF
--- a/aerial_robot_model/src/model/base_model/robot_model.cpp
+++ b/aerial_robot_model/src/model/base_model/robot_model.cpp
@@ -519,7 +519,7 @@ namespace aerial_robot_model {
   double RobotModel::calcTripleProduct(const Eigen::Vector3d& ui, const Eigen::Vector3d& uj, const Eigen::Vector3d& uk)
   {
     Eigen::Vector3d uixuj = ui.cross(uj);
-    if (uixuj.norm() < 0.00001) {
+    if (uixuj.norm() < 10e-5) {
       return 0.0;
     }
     return uixuj.dot(uk) / uixuj.norm();
@@ -563,7 +563,12 @@ namespace aerial_robot_model {
         }
 
         Eigen::Vector3d uixuj = u_i.cross(u_j);
-        fc_f_dists_(index) = fabs(dist_ij - (uixuj.dot(gravity_force) / uixuj.norm()));
+        if (uixuj.norm() < 10e-5) {
+          fc_f_dists_(index) = 0;
+        } else {
+          fc_f_dists_(index) = fabs(dist_ij - (uixuj.dot(gravity_force) / uixuj.norm()));
+        }
+
         index++;
       }
     }


### PR DESCRIPTION
### What is this

To calculate distance from orign to the surface of feasible control convex, we need to consider the norm of cross production between two vector, and use it to devide the third vector. Therefore, the norm should not be zero which is the singualr case when two vectors are almost paralell.

### Details
- Please refere to  Eq.17 in https://arxiv.org/pdf/2008.05613. The norm of `(v_i x v_j)` should not be zero. This means it becomes singualr when `v_i` and `v_j` are paralell.
- We introduce a small value about 10e-5 to determine whether the norm is almost zero.
- Corresponding rostest is performed in [hydrus_xi_jacobian.test](https://github.com/jsk-ros-pkg/jsk_aerial_robot/blob/master/robots/hydrus_xi/test/hydrus_xi_jacobian.test#L41)
