### PR TITLE
[Navigation] refactor the joy command receiver to support more types of joy controller

### DIFF
--- a/aerial_robot_base/src/aerial_robot_base/state_machine.py
+++ b/aerial_robot_base/src/aerial_robot_base/state_machine.py
@@ -84,17 +84,26 @@ class Start(BaseState):
     def joyCallback(self, msg):
 
         # Check interfering from joy
+        interfere_flag = False
+
+        # This is PS4 Joy Controller
         if len(msg.axes) == 14 and len(msg.buttons) == 14:
-            # This is PS4 Joy Controller
             if msg.buttons[4] == 1 and msg.buttons[5] == 1:
 
-                if not self.flags['interfere_mode']:
-                    rospy.loginfo("Enter interfere mode")
-                    self.flags['interfere_mode'] = True
+                interfere_flag = True
 
-                self.flags['interfering'] = True
-            else:
-                self.flags['interfering'] = False
+        # This is RoG1 Controller
+        if len(msg.axes) == 8 and len(msg.buttons) == 11:
+            if msg.buttons[4] == 1 and msg.buttons[5] == 1:
+
+                interfere_flag = True
+
+        if interfere_flag:
+            if not self.flags['interfere_mode']:
+                rospy.loginfo("Enter interfere mode")
+                self.flags['interfere_mode'] = True
+
+        self.flags['interfering'] = interfere_flag
 
     def execute(self, userdata):
 

--- a/aerial_robot_control/CMakeLists.txt
+++ b/aerial_robot_control/CMakeLists.txt
@@ -66,7 +66,7 @@ target_link_libraries(flight_control_pluginlib ${catkin_LIBRARIES} control_utils
 add_dependencies(flight_control_pluginlib  ${PROJECT_NAME}_gencfg)
 
 ### flight navigation
-add_library (flight_navigation src/flight_navigation.cpp)
+add_library (flight_navigation src/flight_navigation.cpp src/util/joy_parser.cpp)
 target_link_libraries (flight_navigation ${catkin_LIBRARIES})
 
 ### trajectory generate based on dodgelib

--- a/aerial_robot_control/include/aerial_robot_control/util/joy_parser.h
+++ b/aerial_robot_control/include/aerial_robot_control/util/joy_parser.h
@@ -40,7 +40,7 @@
 
 /* general joystick bottons/axes layout */
 const int JOY_BUTTON_SIZE              = 17;
-const int JOY_BUTTON_SELECT            = 0;
+const int JOY_BUTTON_STOP            = 0;
 const int JOY_BUTTON_STICK_LEFT        = 1;
 const int JOY_BUTTON_STICK_RIGHT       = 2;
 const int JOY_BUTTON_START             = 3;
@@ -114,6 +114,54 @@ const int PS4_AXIS_BUTTON_CROSS_UP_DOWN    = 10; // up = +1, down= -1
 const int PS4_AXIS_GYRO_ROLL               = 11;
 const int PS4_AXIS_GYRO_YAW                = 12;
 const int PS4_AXIS_GYRO_PITCH              = 13;
+
+/* ps4-like bluetooth joystick */
+const int BLT_BUTTON_SIZE              = 13;
+const int BLT_BUTTON_ACTION_CROSS      = 0;
+const int BLT_BUTTON_ACTION_CIRCLE     = 1;
+const int BLT_BUTTON_ACTION_TRIANGLE   = 2;
+const int BLT_BUTTON_ACTION_SQUARE     = 3;
+const int BLT_BUTTON_REAR_LEFT_1       = 4;
+const int BLT_BUTTON_REAR_RIGHT_1      = 5;
+const int BLT_BUTTON_REAR_LEFT_2       = 6;
+const int BLT_BUTTON_REAR_RIGHT_2      = 7;
+const int BLT_BUTTON_SHARE             = 8;
+const int BLT_BUTTON_OPTIONS           = 9;
+const int BLT_BUTTON_PAIRING           = 10;
+const int BLT_BUTTON_STICK_LEFT        = 11;
+const int BLT_BUTTON_STICK_RIGHT       = 12;
+const int BLT_AXIS_SIZE                    = 8;
+const int BLT_AXIS_STICK_LEFT_LEFTWARDS    = 0;
+const int BLT_AXIS_STICK_LEFT_UPWARDS      = 1;
+const int BLT_AXIS_BUTTON_REAR_LEFT_2      = 2; // neutral=+1, full accel=-1
+const int BLT_AXIS_STICK_RIGHT_LEFTWARDS   = 3;
+const int BLT_AXIS_STICK_RIGHT_UPWARDS     = 4;
+const int BLT_AXIS_BUTTON_REAR_RIGHT_2     = 5; // neutral=+1, full accel=-1
+const int BLT_AXIS_BUTTON_CROSS_LEFT_RIGHT = 6; // left = +1, right= -1
+const int BLT_AXIS_BUTTON_CROSS_UP_DOWN    = 7; // up = +1, down= -1
+
+/* ROG1 embeded joystick */
+const int ROG1_BUTTON_SIZE              = 11;
+const int ROG1_BUTTON_ACTION_A          = 0;
+const int ROG1_BUTTON_ACTION_B          = 1;
+const int ROG1_BUTTON_ACTION_X          = 2;
+const int ROG1_BUTTON_ACTION_Y          = 3;
+const int ROG1_BUTTON_REAR_LEFT_1       = 4;
+const int ROG1_BUTTON_REAR_RIGHT_1      = 5;
+const int ROG1_BUTTON_DUO_RECT          = 6;
+const int ROG1_BUTTON_TRI_LINE          = 7;
+const int ROG1_BUTTON_STICK_LEFT        = 9;
+const int ROG1_BUTTON_STICK_RIGHT       = 10;
+const int ROG1_AXIS_SIZE                    = 8;
+const int ROG1_AXIS_STICK_LEFT_LEFTWARDS    = 0;
+const int ROG1_AXIS_STICK_LEFT_UPWARDS      = 1;
+const int ROG1_AXIS_BUTTON_REAR_LEFT_2      = 2; // neutral=+1, full accel=-1
+const int ROG1_AXIS_STICK_RIGHT_LEFTWARDS   = 3;
+const int ROG1_AXIS_STICK_RIGHT_UPWARDS     = 4;
+const int ROG1_AXIS_BUTTON_REAR_RIGHT_2     = 5; // neutral=+1, full accel=-1
+const int ROG1_AXIS_BUTTON_CROSS_LEFT_RIGHT = 6; // left = +1, right= -1
+const int ROG1_AXIS_BUTTON_CROSS_UP_DOWN    = 7; // up = +1, down= -1
+
 
 const sensor_msgs::Joy joyParse(const sensor_msgs::Joy& ps4_joy_msg);
 

--- a/aerial_robot_control/include/aerial_robot_control/util/joy_parser.h
+++ b/aerial_robot_control/include/aerial_robot_control/util/joy_parser.h
@@ -1,0 +1,119 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2025, DRAGON Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#pragma once
+
+#include <sensor_msgs/Joy.h>
+
+/* general joystick bottons/axes layout */
+const int JOY_BUTTON_SIZE              = 17;
+const int JOY_BUTTON_SELECT            = 0;
+const int JOY_BUTTON_STICK_LEFT        = 1;
+const int JOY_BUTTON_STICK_RIGHT       = 2;
+const int JOY_BUTTON_START             = 3;
+const int JOY_BUTTON_CROSS_UP          = 4;
+const int JOY_BUTTON_CROSS_RIGHT       = 5;
+const int JOY_BUTTON_CROSS_DOWN        = 6;
+const int JOY_BUTTON_CROSS_LEFT        = 7;
+const int JOY_BUTTON_REAR_LEFT_2       = 8;
+const int JOY_BUTTON_REAR_RIGHT_2      = 9;
+const int JOY_BUTTON_REAR_LEFT_1       = 10;
+const int JOY_BUTTON_REAR_RIGHT_1      = 11;
+const int JOY_BUTTON_ACTION_TRIANGLE   = 12;
+const int JOY_BUTTON_ACTION_CIRCLE     = 13;
+const int JOY_BUTTON_ACTION_CROSS      = 14;
+const int JOY_BUTTON_ACTION_SQUARE     = 15;
+const int JOY_BUTTON_PAIRING           = 16;
+const int JOY_AXIS_SIZE                    = 29;
+const int JOY_AXIS_STICK_LEFT_LEFTWARDS    = 0;
+const int JOY_AXIS_STICK_LEFT_UPWARDS      = 1;
+const int JOY_AXIS_STICK_RIGHT_LEFTWARDS   = 2;
+const int JOY_AXIS_STICK_RIGHT_UPWARDS     = 3;
+const int JOY_AXIS_BUTTON_CROSS_UP         = 4;
+const int JOY_AXIS_BUTTON_CROSS_RIGHT      = 5;
+const int JOY_AXIS_BUTTON_CROSS_DOWN       = 6;
+const int JOY_AXIS_BUTTON_CROSS_LEFT       = 7;
+const int JOY_AXIS_BUTTON_REAR_LEFT_2      = 8;
+const int JOY_AXIS_BUTTON_REAR_RIGHT_2     = 9;
+const int JOY_AXIS_BUTTON_REAR_LEFT_1      = 10;
+const int JOY_AXIS_BUTTON_REAR_RIGHT_1     = 11;
+const int JOY_AXIS_BUTTON_ACTION_TRIANGLE  = 12;
+const int JOY_AXIS_BUTTON_ACTION_CIRCLE    = 13;
+const int JOY_AXIS_BUTTON_ACTION_CROSS     = 14;
+const int JOY_AXIS_BUTTON_ACTION_SQUARE    = 15;
+const int JOY_AXIS_ACCELEROMETER_LEFT      = 16;
+const int JOY_AXIS_ACCELEROMETER_FORWARD   = 17;
+const int JOY_AXIS_ACCELEROMETER_UP        = 18;
+const int JOY_AXIS_GYRO_YAW                = 19;
+
+/* playstation dualschock 3 joystick: same with general layout */
+const int PS3_BUTTON_SIZE                  = 17;
+const int PS3_AXIS_SIZE                    = 29;
+
+/* playstation dualschock 4 joystick */
+const int PS4_BUTTON_SIZE              = 14;
+const int PS4_BUTTON_ACTION_SQUARE     = 0;
+const int PS4_BUTTON_ACTION_CROSS      = 1;
+const int PS4_BUTTON_ACTION_CIRCLE     = 2;
+const int PS4_BUTTON_ACTION_TRIANGLE   = 3;
+const int PS4_BUTTON_REAR_LEFT_1       = 4;
+const int PS4_BUTTON_REAR_RIGHT_1      = 5;
+const int PS4_BUTTON_REAR_LEFT_2       = 6;
+const int PS4_BUTTON_REAR_RIGHT_2      = 7;
+const int PS4_BUTTON_SHARE             = 8;
+const int PS4_BUTTON_OPTIONS           = 9;
+const int PS4_BUTTON_STICK_LEFT        = 10;
+const int PS4_BUTTON_STICK_RIGHT       = 11;
+const int PS4_BUTTON_PAIRING           = 12;
+const int PS4_BUTTON_TOUCHPAD          = 13;
+const int PS4_AXIS_SIZE                    = 14;
+const int PS4_AXIS_STICK_LEFT_LEFTWARDS    = 0;
+const int PS4_AXIS_STICK_LEFT_UPWARDS      = 1;
+const int PS4_AXIS_STICK_RIGHT_LEFTWARDS   = 2;
+const int PS4_AXIS_BUTTON_REAR_LEFT_2      = 3; // neutral=+1, full accel=-1
+const int PS4_AXIS_BUTTON_REAR_RIGHT_2     = 4; // neutral=+1, full accel=-1
+const int PS4_AXIS_STICK_RIGHT_UPWARDS     = 5;
+const int PS4_AXIS_ACCELEROMETER_LEFT      = 6;
+const int PS4_AXIS_ACCELEROMETER_FORWARD   = 7;
+const int PS4_AXIS_ACCELEROMETER_UP        = 8;
+const int PS4_AXIS_BUTTON_CROSS_LEFT_RIGHT = 9; // left = +1, right= -1
+const int PS4_AXIS_BUTTON_CROSS_UP_DOWN    = 10; // up = +1, down= -1
+const int PS4_AXIS_GYRO_ROLL               = 11;
+const int PS4_AXIS_GYRO_YAW                = 12;
+const int PS4_AXIS_GYRO_PITCH              = 13;
+
+const sensor_msgs::Joy joyParse(const sensor_msgs::Joy& ps4_joy_msg);
+

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -331,35 +331,26 @@ void BaseNavigator::naviCallback(const aerial_robot_msgs::FlightNavConstPtr & ms
 
 void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
 {
-  sensor_msgs::Joy joy_cmd;
-  if(joy_msg->axes.size() == PS3_AXES && joy_msg->buttons.size() == PS3_BUTTONS)
-    {
-      joy_cmd = (*joy_msg);
-    }
-  else if(joy_msg->axes.size() == PS4_AXES && joy_msg->buttons.size() == PS4_BUTTONS)
-    {
-      joy_cmd = joyParse(*joy_msg);
-    }
-  else
+  sensor_msgs::Joy joy_cmd = joyParse(*joy_msg);
+  if (joy_cmd.axes.size() == 0 || joy_cmd.buttons.size() == 0)
     {
       ROS_WARN("the joystick type is not supported (buttons: %d, axes: %d)", (int)joy_msg->buttons.size(), (int)joy_msg->axes.size());
       return;
     }
 
-  /* ps3 joy bottons assignment: http://wiki.ros.org/ps3joy */
   if(!joy_stick_heart_beat_) joy_stick_heart_beat_ = true;
   joy_stick_prev_time_ = ros::Time::now().toSec();
 
   /* common command */
   /* start */
-  if(joy_cmd.buttons[PS3_BUTTON_START] == 1 && getNaviState() == ARM_OFF_STATE)
+  if(joy_cmd.buttons[JOY_BUTTON_START] == 1 && getNaviState() == ARM_OFF_STATE)
     {
       motorArming();
       return;
     }
 
   /* force landing && halt */
-  if(joy_cmd.buttons[PS3_BUTTON_SELECT] == 1)
+  if(joy_cmd.buttons[JOY_BUTTON_STOP] == 1)
     {
       /* Force Landing in inflight mode: TAKEOFF_STATE/LAND_STATE/HOVER_STATE */
       if(!force_landing_flag_ && (getNaviState() == TAKEOFF_STATE || getNaviState() == LAND_STATE || getNaviState() == HOVER_STATE))
@@ -396,14 +387,14 @@ void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
     }
 
   /* takeoff */
-  if(joy_cmd.buttons[PS3_BUTTON_CROSS_LEFT] == 1 && joy_cmd.buttons[PS3_BUTTON_ACTION_CIRCLE] == 1)
+  if(joy_cmd.buttons[JOY_BUTTON_CROSS_LEFT] == 1 && joy_cmd.buttons[JOY_BUTTON_ACTION_CIRCLE] == 1)
     {
       startTakeoff();
       return;
     }
 
   /* landing */
-  if(joy_cmd.buttons[PS3_BUTTON_CROSS_RIGHT] == 1 && joy_cmd.buttons[PS3_BUTTON_ACTION_SQUARE] == 1)
+  if(joy_cmd.buttons[JOY_BUTTON_CROSS_RIGHT] == 1 && joy_cmd.buttons[JOY_BUTTON_ACTION_SQUARE] == 1)
     {
       if(force_att_control_flag_) return;
 
@@ -419,10 +410,10 @@ void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
 
   teleop_reset_time_ = teleop_reset_duration_ + ros::Time::now().toSec();
 
-  double raw_x_cmd = joy_cmd.axes[PS3_AXIS_STICK_LEFT_UPWARDS];
-  double raw_y_cmd = joy_cmd.axes[PS3_AXIS_STICK_LEFT_LEFTWARDS];
-  double raw_z_cmd = joy_cmd.axes[PS3_AXIS_STICK_RIGHT_UPWARDS];
-  double raw_yaw_cmd = joy_cmd.axes[PS3_AXIS_STICK_RIGHT_LEFTWARDS];
+  double raw_x_cmd = joy_cmd.axes[JOY_AXIS_STICK_LEFT_UPWARDS];
+  double raw_y_cmd = joy_cmd.axes[JOY_AXIS_STICK_LEFT_LEFTWARDS];
+  double raw_z_cmd = joy_cmd.axes[JOY_AXIS_STICK_RIGHT_UPWARDS];
+  double raw_yaw_cmd = joy_cmd.axes[JOY_AXIS_STICK_RIGHT_LEFTWARDS];
 
   /* Motion: Z (Height) */
   if(getNaviState() == HOVER_STATE)
@@ -455,7 +446,7 @@ void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
 
   /* mode selection */
   /* switch to acc model */
-  if(joy_cmd.buttons[PS3_BUTTON_CROSS_DOWN] == 1)
+  if(joy_cmd.buttons[JOY_BUTTON_CROSS_DOWN] == 1)
     {
       if (xy_control_mode_ != ACC_CONTROL_MODE)
         {
@@ -467,7 +458,7 @@ void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
     }
 
   /* switch to pure vel mode */
-  if(joy_cmd.buttons[PS3_BUTTON_ACTION_TRIANGLE] == 1)
+  if(joy_cmd.buttons[JOY_BUTTON_ACTION_TRIANGLE] == 1)
     {
       if (xy_control_mode_ != VEL_CONTROL_MODE)
         {
@@ -480,7 +471,7 @@ void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
     }
 
   /* siwthc to pos mode */
-  if(joy_cmd.buttons[PS3_BUTTON_ACTION_CROSS] == 1)
+  if(joy_cmd.buttons[JOY_BUTTON_ACTION_CROSS] == 1)
     {
       if (xy_control_mode_ != POS_CONTROL_MODE)
         {
@@ -497,7 +488,7 @@ void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
   /* mode oriented state */
   control_frame_ = WORLD_FRAME;
   tf::Matrix3x3 local_frame_rot;
-  if(joy_cmd.buttons[PS3_BUTTON_REAR_LEFT_2])
+  if(joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_2])
     {
       control_frame_ = LOCAL_FRAME;
 

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -1,4 +1,5 @@
 #include "aerial_robot_control/flight_navigation.h"
+#include "aerial_robot_control/util/joy_parser.h"
 
 using namespace std;
 using namespace aerial_robot_navigation;
@@ -328,46 +329,6 @@ void BaseNavigator::naviCallback(const aerial_robot_msgs::FlightNavConstPtr & ms
   if(msg->pos_xy_nav_mode != aerial_robot_msgs::FlightNav::ACC_MODE) setTargetZeroAcc();
 }
 
-const sensor_msgs::Joy BaseNavigator::ps4joyToPs3joyConvert(const sensor_msgs::Joy& ps4_joy_msg)
-{
-  /* hard coding */
-  sensor_msgs::Joy joy_cmd;
-  joy_cmd.header = ps4_joy_msg.header;
-  joy_cmd.axes.resize(PS3_AXES, 0);
-  joy_cmd.buttons.resize(PS3_BUTTONS, 0);
-  joy_cmd.buttons[PS3_BUTTON_SELECT] = ps4_joy_msg.buttons[PS4_BUTTON_SHARE];
-  joy_cmd.buttons[PS3_BUTTON_STICK_LEFT] = ps4_joy_msg.buttons[PS4_BUTTON_STICK_LEFT];
-  joy_cmd.buttons[PS3_BUTTON_STICK_RIGHT] = ps4_joy_msg.buttons[PS4_BUTTON_STICK_RIGHT];
-  joy_cmd.buttons[PS3_BUTTON_START] = ps4_joy_msg.buttons[PS4_BUTTON_OPTIONS];
-  if(ps4_joy_msg.axes[PS4_AXIS_BUTTON_CROSS_UP_DOWN] == 1)
-    joy_cmd.buttons[PS3_BUTTON_CROSS_UP] = 1;
-  if(ps4_joy_msg.axes[PS4_AXIS_BUTTON_CROSS_UP_DOWN] == -1)
-    joy_cmd.buttons[PS3_BUTTON_CROSS_DOWN] = 1;
-  if(ps4_joy_msg.axes[PS4_AXIS_BUTTON_CROSS_LEFT_RIGHT] == 1)
-    joy_cmd.buttons[PS3_BUTTON_CROSS_LEFT] = 1;
-  if(ps4_joy_msg.axes[PS4_AXIS_BUTTON_CROSS_LEFT_RIGHT] == -1)
-    joy_cmd.buttons[PS3_BUTTON_CROSS_RIGHT] = 1;
-  joy_cmd.buttons[PS3_BUTTON_REAR_LEFT_2] = ps4_joy_msg.buttons[PS4_BUTTON_REAR_LEFT_2];
-  joy_cmd.buttons[PS3_BUTTON_REAR_RIGHT_2] = ps4_joy_msg.buttons[PS4_BUTTON_REAR_RIGHT_2];
-  joy_cmd.buttons[PS3_BUTTON_REAR_LEFT_1] = ps4_joy_msg.buttons[PS4_BUTTON_REAR_LEFT_1];
-  joy_cmd.buttons[PS3_BUTTON_REAR_RIGHT_1] = ps4_joy_msg.buttons[PS4_BUTTON_REAR_RIGHT_1];
-  joy_cmd.buttons[PS3_BUTTON_ACTION_TRIANGLE] = ps4_joy_msg.buttons[PS4_BUTTON_ACTION_TRIANGLE];
-  joy_cmd.buttons[PS3_BUTTON_ACTION_CIRCLE] = ps4_joy_msg.buttons[PS4_BUTTON_ACTION_CIRCLE];
-  joy_cmd.buttons[PS3_BUTTON_ACTION_CROSS] = ps4_joy_msg.buttons[PS4_BUTTON_ACTION_CROSS];
-  joy_cmd.buttons[PS3_BUTTON_ACTION_SQUARE] = ps4_joy_msg.buttons[PS4_BUTTON_ACTION_SQUARE];
-  joy_cmd.buttons[PS3_BUTTON_PAIRING] = ps4_joy_msg.buttons[PS4_BUTTON_PAIRING];
-  joy_cmd.axes[PS3_AXIS_STICK_LEFT_LEFTWARDS] = ps4_joy_msg.axes[PS4_AXIS_STICK_LEFT_LEFTWARDS];
-  joy_cmd.axes[PS3_AXIS_STICK_LEFT_UPWARDS] = ps4_joy_msg.axes[PS4_AXIS_STICK_LEFT_UPWARDS];
-  joy_cmd.axes[PS3_AXIS_STICK_RIGHT_LEFTWARDS] = ps4_joy_msg.axes[PS4_AXIS_STICK_RIGHT_LEFTWARDS];
-  joy_cmd.axes[PS3_AXIS_STICK_RIGHT_UPWARDS] = ps4_joy_msg.axes[PS4_AXIS_STICK_RIGHT_UPWARDS];
-  joy_cmd.axes[PS3_AXIS_ACCELEROMETER_LEFT] = ps4_joy_msg.axes[PS4_AXIS_ACCELEROMETER_LEFT];
-  joy_cmd.axes[PS3_AXIS_ACCELEROMETER_FORWARD] = ps4_joy_msg.axes[PS4_AXIS_ACCELEROMETER_FORWARD];
-  joy_cmd.axes[PS3_AXIS_ACCELEROMETER_UP] = ps4_joy_msg.axes[PS4_AXIS_ACCELEROMETER_UP];
-  joy_cmd.axes[PS3_AXIS_GYRO_YAW] = ps4_joy_msg.axes[PS4_AXIS_GYRO_YAW];
-  return joy_cmd;
-}
-
-
 void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
 {
   sensor_msgs::Joy joy_cmd;
@@ -377,7 +338,7 @@ void BaseNavigator::joyStickControl(const sensor_msgs::JoyConstPtr & joy_msg)
     }
   else if(joy_msg->axes.size() == PS4_AXES && joy_msg->buttons.size() == PS4_BUTTONS)
     {
-      joy_cmd = ps4joyToPs3joyConvert(*joy_msg);
+      joy_cmd = joyParse(*joy_msg);
     }
   else
     {

--- a/aerial_robot_control/src/util/joy_parser.cpp
+++ b/aerial_robot_control/src/util/joy_parser.cpp
@@ -17,10 +17,10 @@ const sensor_msgs::Joy joyParse(const sensor_msgs::Joy& joy_msg)
       joy_cmd.header = joy_msg.header;
       joy_cmd.axes.resize(JOY_AXIS_SIZE, 0);
       joy_cmd.buttons.resize(JOY_BUTTON_SIZE, 0);
-      joy_cmd.buttons[JOY_BUTTON_SELECT] = joy_msg.buttons[PS4_BUTTON_SHARE];
+      joy_cmd.buttons[JOY_BUTTON_START] = joy_msg.buttons[PS4_BUTTON_OPTIONS];
+      joy_cmd.buttons[JOY_BUTTON_STOP] = joy_msg.buttons[PS4_BUTTON_SHARE];
       joy_cmd.buttons[JOY_BUTTON_STICK_LEFT] = joy_msg.buttons[PS4_BUTTON_STICK_LEFT];
       joy_cmd.buttons[JOY_BUTTON_STICK_RIGHT] = joy_msg.buttons[PS4_BUTTON_STICK_RIGHT];
-      joy_cmd.buttons[JOY_BUTTON_START] = joy_msg.buttons[PS4_BUTTON_OPTIONS];
       if(joy_msg.axes[PS4_AXIS_BUTTON_CROSS_UP_DOWN] == 1)
         joy_cmd.buttons[JOY_BUTTON_CROSS_UP] = 1;
       if(joy_msg.axes[PS4_AXIS_BUTTON_CROSS_UP_DOWN] == -1)
@@ -29,10 +29,10 @@ const sensor_msgs::Joy joyParse(const sensor_msgs::Joy& joy_msg)
         joy_cmd.buttons[JOY_BUTTON_CROSS_LEFT] = 1;
       if(joy_msg.axes[PS4_AXIS_BUTTON_CROSS_LEFT_RIGHT] == -1)
         joy_cmd.buttons[JOY_BUTTON_CROSS_RIGHT] = 1;
-      joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_2] = joy_msg.buttons[PS4_BUTTON_REAR_LEFT_2];
-      joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_2] = joy_msg.buttons[PS4_BUTTON_REAR_RIGHT_2];
       joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_1] = joy_msg.buttons[PS4_BUTTON_REAR_LEFT_1];
       joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_1] = joy_msg.buttons[PS4_BUTTON_REAR_RIGHT_1];
+      joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_2] = joy_msg.buttons[PS4_BUTTON_REAR_LEFT_2];
+      joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_2] = joy_msg.buttons[PS4_BUTTON_REAR_RIGHT_2];
       joy_cmd.buttons[JOY_BUTTON_ACTION_TRIANGLE] = joy_msg.buttons[PS4_BUTTON_ACTION_TRIANGLE];
       joy_cmd.buttons[JOY_BUTTON_ACTION_CIRCLE] = joy_msg.buttons[PS4_BUTTON_ACTION_CIRCLE];
       joy_cmd.buttons[JOY_BUTTON_ACTION_CROSS] = joy_msg.buttons[PS4_BUTTON_ACTION_CROSS];
@@ -46,6 +46,101 @@ const sensor_msgs::Joy joyParse(const sensor_msgs::Joy& joy_msg)
       joy_cmd.axes[JOY_AXIS_ACCELEROMETER_FORWARD] = joy_msg.axes[PS4_AXIS_ACCELEROMETER_FORWARD];
       joy_cmd.axes[JOY_AXIS_ACCELEROMETER_UP] = joy_msg.axes[PS4_AXIS_ACCELEROMETER_UP];
       joy_cmd.axes[JOY_AXIS_GYRO_YAW] = joy_msg.axes[PS4_AXIS_GYRO_YAW];
+    }
+
+  if (a_size == BLT_AXIS_SIZE && b_size == BLT_BUTTON_SIZE)
+    {
+      joy_cmd.header = joy_msg.header;
+      joy_cmd.axes.resize(JOY_AXIS_SIZE, 0);
+      joy_cmd.buttons.resize(JOY_BUTTON_SIZE, 0);
+      joy_cmd.buttons[JOY_BUTTON_START] = joy_msg.buttons[BLT_BUTTON_OPTIONS];
+      joy_cmd.buttons[JOY_BUTTON_STOP] = joy_msg.buttons[BLT_BUTTON_SHARE];
+      joy_cmd.buttons[JOY_BUTTON_STICK_LEFT] = joy_msg.buttons[BLT_BUTTON_STICK_LEFT];
+      joy_cmd.buttons[JOY_BUTTON_STICK_RIGHT] = joy_msg.buttons[BLT_BUTTON_STICK_RIGHT];
+      if(joy_msg.axes[BLT_AXIS_BUTTON_CROSS_UP_DOWN] == 1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_UP] = 1;
+      if(joy_msg.axes[BLT_AXIS_BUTTON_CROSS_UP_DOWN] == -1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_DOWN] = 1;
+      if(joy_msg.axes[BLT_AXIS_BUTTON_CROSS_LEFT_RIGHT] == 1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_LEFT] = 1;
+      if(joy_msg.axes[BLT_AXIS_BUTTON_CROSS_LEFT_RIGHT] == -1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_RIGHT] = 1;
+      joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_1] = joy_msg.buttons[BLT_BUTTON_REAR_LEFT_1];
+      joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_1] = joy_msg.buttons[BLT_BUTTON_REAR_RIGHT_1];
+      joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_2] = joy_msg.buttons[BLT_BUTTON_REAR_LEFT_2];
+      joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_2] = joy_msg.buttons[BLT_BUTTON_REAR_RIGHT_2];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_TRIANGLE] = joy_msg.buttons[BLT_BUTTON_ACTION_TRIANGLE];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_CIRCLE] = joy_msg.buttons[BLT_BUTTON_ACTION_CIRCLE];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_CROSS] = joy_msg.buttons[BLT_BUTTON_ACTION_CROSS];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_SQUARE] = joy_msg.buttons[BLT_BUTTON_ACTION_SQUARE];
+      joy_cmd.buttons[JOY_BUTTON_PAIRING] = joy_msg.buttons[BLT_BUTTON_PAIRING];
+      joy_cmd.axes[JOY_AXIS_STICK_LEFT_LEFTWARDS] = joy_msg.axes[BLT_AXIS_STICK_LEFT_LEFTWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_LEFT_UPWARDS] = joy_msg.axes[BLT_AXIS_STICK_LEFT_UPWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_RIGHT_LEFTWARDS] = joy_msg.axes[BLT_AXIS_STICK_RIGHT_LEFTWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_RIGHT_UPWARDS] = joy_msg.axes[BLT_AXIS_STICK_RIGHT_UPWARDS];
+    }
+
+    if (a_size == BLT_AXIS_SIZE && b_size == BLT_BUTTON_SIZE)
+    {
+      joy_cmd.header = joy_msg.header;
+      joy_cmd.axes.resize(JOY_AXIS_SIZE, 0);
+      joy_cmd.buttons.resize(JOY_BUTTON_SIZE, 0);
+      joy_cmd.buttons[JOY_BUTTON_START] = joy_msg.buttons[BLT_BUTTON_OPTIONS];
+      joy_cmd.buttons[JOY_BUTTON_STOP] = joy_msg.buttons[BLT_BUTTON_SHARE];
+      joy_cmd.buttons[JOY_BUTTON_STICK_LEFT] = joy_msg.buttons[BLT_BUTTON_STICK_LEFT];
+      joy_cmd.buttons[JOY_BUTTON_STICK_RIGHT] = joy_msg.buttons[BLT_BUTTON_STICK_RIGHT];
+      if(joy_msg.axes[BLT_AXIS_BUTTON_CROSS_UP_DOWN] == 1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_UP] = 1;
+      if(joy_msg.axes[BLT_AXIS_BUTTON_CROSS_UP_DOWN] == -1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_DOWN] = 1;
+      if(joy_msg.axes[BLT_AXIS_BUTTON_CROSS_LEFT_RIGHT] == 1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_LEFT] = 1;
+      if(joy_msg.axes[BLT_AXIS_BUTTON_CROSS_LEFT_RIGHT] == -1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_RIGHT] = 1;
+      joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_1] = joy_msg.buttons[BLT_BUTTON_REAR_LEFT_1];
+      joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_1] = joy_msg.buttons[BLT_BUTTON_REAR_RIGHT_1];
+      joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_2] = joy_msg.buttons[BLT_BUTTON_REAR_LEFT_2];
+      joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_2] = joy_msg.buttons[BLT_BUTTON_REAR_RIGHT_2];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_TRIANGLE] = joy_msg.buttons[BLT_BUTTON_ACTION_TRIANGLE];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_CIRCLE] = joy_msg.buttons[BLT_BUTTON_ACTION_CIRCLE];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_CROSS] = joy_msg.buttons[BLT_BUTTON_ACTION_CROSS];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_SQUARE] = joy_msg.buttons[BLT_BUTTON_ACTION_SQUARE];
+      joy_cmd.buttons[JOY_BUTTON_PAIRING] = joy_msg.buttons[BLT_BUTTON_PAIRING];
+      joy_cmd.axes[JOY_AXIS_STICK_LEFT_LEFTWARDS] = joy_msg.axes[BLT_AXIS_STICK_LEFT_LEFTWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_LEFT_UPWARDS] = joy_msg.axes[BLT_AXIS_STICK_LEFT_UPWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_RIGHT_LEFTWARDS] = joy_msg.axes[BLT_AXIS_STICK_RIGHT_LEFTWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_RIGHT_UPWARDS] = joy_msg.axes[BLT_AXIS_STICK_RIGHT_UPWARDS];
+    }
+
+    if (a_size == ROG1_AXIS_SIZE && b_size == ROG1_BUTTON_SIZE)
+    {
+      joy_cmd.header = joy_msg.header;
+      joy_cmd.axes.resize(JOY_AXIS_SIZE, 0);
+      joy_cmd.buttons.resize(JOY_BUTTON_SIZE, 0);
+      joy_cmd.buttons[JOY_BUTTON_START] = joy_msg.buttons[ROG1_BUTTON_TRI_LINE];
+      joy_cmd.buttons[JOY_BUTTON_STOP] = joy_msg.buttons[ROG1_BUTTON_DUO_RECT];
+      joy_cmd.buttons[JOY_BUTTON_STICK_LEFT] = joy_msg.buttons[ROG1_BUTTON_STICK_LEFT];
+      joy_cmd.buttons[JOY_BUTTON_STICK_RIGHT] = joy_msg.buttons[ROG1_BUTTON_STICK_RIGHT];
+      if(joy_msg.axes[ROG1_AXIS_BUTTON_CROSS_UP_DOWN] == 1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_UP] = 1;
+      if(joy_msg.axes[ROG1_AXIS_BUTTON_CROSS_UP_DOWN] == -1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_DOWN] = 1;
+      if(joy_msg.axes[ROG1_AXIS_BUTTON_CROSS_LEFT_RIGHT] == 1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_LEFT] = 1;
+      if(joy_msg.axes[ROG1_AXIS_BUTTON_CROSS_LEFT_RIGHT] == -1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_RIGHT] = 1;
+      joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_1] = joy_msg.buttons[ROG1_BUTTON_REAR_LEFT_1];
+      joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_1] = joy_msg.buttons[ROG1_BUTTON_REAR_RIGHT_1];
+      joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_2] = (joy_msg.axes[ROG1_AXIS_BUTTON_REAR_LEFT_2]==-1)?1:0;
+      joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_2] = (joy_msg.axes[ROG1_AXIS_BUTTON_REAR_RIGHT_2]==-1)?1:0;
+      joy_cmd.buttons[JOY_BUTTON_ACTION_CROSS] = joy_msg.buttons[ROG1_BUTTON_ACTION_A];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_CIRCLE] = joy_msg.buttons[ROG1_BUTTON_ACTION_B];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_SQUARE] = joy_msg.buttons[ROG1_BUTTON_ACTION_X];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_TRIANGLE] = joy_msg.buttons[ROG1_BUTTON_ACTION_Y];
+      joy_cmd.axes[JOY_AXIS_STICK_LEFT_LEFTWARDS] = joy_msg.axes[ROG1_AXIS_STICK_LEFT_LEFTWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_LEFT_UPWARDS] = joy_msg.axes[ROG1_AXIS_STICK_LEFT_UPWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_RIGHT_LEFTWARDS] = joy_msg.axes[ROG1_AXIS_STICK_RIGHT_LEFTWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_RIGHT_UPWARDS] = joy_msg.axes[ROG1_AXIS_STICK_RIGHT_UPWARDS];
     }
 
   return joy_cmd;

--- a/aerial_robot_control/src/util/joy_parser.cpp
+++ b/aerial_robot_control/src/util/joy_parser.cpp
@@ -1,0 +1,52 @@
+#include "aerial_robot_control/util/joy_parser.h"
+
+const sensor_msgs::Joy joyParse(const sensor_msgs::Joy& joy_msg)
+{
+  sensor_msgs::Joy joy_cmd;
+
+  int a_size = joy_msg.axes.size();
+  int b_size = joy_msg.buttons.size();
+
+  if (a_size == PS3_AXIS_SIZE && b_size == PS3_BUTTON_SIZE)
+    {
+      joy_cmd = joy_msg;
+    }
+
+  if (a_size == PS4_AXIS_SIZE && b_size == PS4_BUTTON_SIZE)
+    {
+      joy_cmd.header = joy_msg.header;
+      joy_cmd.axes.resize(JOY_AXIS_SIZE, 0);
+      joy_cmd.buttons.resize(JOY_BUTTON_SIZE, 0);
+      joy_cmd.buttons[JOY_BUTTON_SELECT] = joy_msg.buttons[PS4_BUTTON_SHARE];
+      joy_cmd.buttons[JOY_BUTTON_STICK_LEFT] = joy_msg.buttons[PS4_BUTTON_STICK_LEFT];
+      joy_cmd.buttons[JOY_BUTTON_STICK_RIGHT] = joy_msg.buttons[PS4_BUTTON_STICK_RIGHT];
+      joy_cmd.buttons[JOY_BUTTON_START] = joy_msg.buttons[PS4_BUTTON_OPTIONS];
+      if(joy_msg.axes[PS4_AXIS_BUTTON_CROSS_UP_DOWN] == 1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_UP] = 1;
+      if(joy_msg.axes[PS4_AXIS_BUTTON_CROSS_UP_DOWN] == -1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_DOWN] = 1;
+      if(joy_msg.axes[PS4_AXIS_BUTTON_CROSS_LEFT_RIGHT] == 1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_LEFT] = 1;
+      if(joy_msg.axes[PS4_AXIS_BUTTON_CROSS_LEFT_RIGHT] == -1)
+        joy_cmd.buttons[JOY_BUTTON_CROSS_RIGHT] = 1;
+      joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_2] = joy_msg.buttons[PS4_BUTTON_REAR_LEFT_2];
+      joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_2] = joy_msg.buttons[PS4_BUTTON_REAR_RIGHT_2];
+      joy_cmd.buttons[JOY_BUTTON_REAR_LEFT_1] = joy_msg.buttons[PS4_BUTTON_REAR_LEFT_1];
+      joy_cmd.buttons[JOY_BUTTON_REAR_RIGHT_1] = joy_msg.buttons[PS4_BUTTON_REAR_RIGHT_1];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_TRIANGLE] = joy_msg.buttons[PS4_BUTTON_ACTION_TRIANGLE];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_CIRCLE] = joy_msg.buttons[PS4_BUTTON_ACTION_CIRCLE];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_CROSS] = joy_msg.buttons[PS4_BUTTON_ACTION_CROSS];
+      joy_cmd.buttons[JOY_BUTTON_ACTION_SQUARE] = joy_msg.buttons[PS4_BUTTON_ACTION_SQUARE];
+      joy_cmd.buttons[JOY_BUTTON_PAIRING] = joy_msg.buttons[PS4_BUTTON_PAIRING];
+      joy_cmd.axes[JOY_AXIS_STICK_LEFT_LEFTWARDS] = joy_msg.axes[PS4_AXIS_STICK_LEFT_LEFTWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_LEFT_UPWARDS] = joy_msg.axes[PS4_AXIS_STICK_LEFT_UPWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_RIGHT_LEFTWARDS] = joy_msg.axes[PS4_AXIS_STICK_RIGHT_LEFTWARDS];
+      joy_cmd.axes[JOY_AXIS_STICK_RIGHT_UPWARDS] = joy_msg.axes[PS4_AXIS_STICK_RIGHT_UPWARDS];
+      joy_cmd.axes[JOY_AXIS_ACCELEROMETER_LEFT] = joy_msg.axes[PS4_AXIS_ACCELEROMETER_LEFT];
+      joy_cmd.axes[JOY_AXIS_ACCELEROMETER_FORWARD] = joy_msg.axes[PS4_AXIS_ACCELEROMETER_FORWARD];
+      joy_cmd.axes[JOY_AXIS_ACCELEROMETER_UP] = joy_msg.axes[PS4_AXIS_ACCELEROMETER_UP];
+      joy_cmd.axes[JOY_AXIS_GYRO_YAW] = joy_msg.axes[PS4_AXIS_GYRO_YAW];
+    }
+
+  return joy_cmd;
+}


### PR DESCRIPTION
### What is this

Refactor the conversion of joy command, and support more types of joy controller

### Details

- extract the joy conversion function to independent file:s `aerial_robot_control/include/aerial_robot_control/util/joy_parser.h` and `aerial_robot_control/src/util/joy_parser.cpp`
- support other joy controller to do navigation and smach based simple demo 


### New supported controller
- ps4-like bluetooth joy controller:
![IMG_8950](https://github.com/user-attachments/assets/4ed10d95-6d88-4f6b-8a35-e633effe8f8c)


- support common RoG Ally:
![image](https://github.com/user-attachments/assets/42e7c94a-d7db-46a1-bce0-d2e8aae68b75)



