### PR TITLE
[Navigation][Trajectory] avoid the wrong access to empty trajectory generator just after reset

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
+++ b/aerial_robot_control/include/aerial_robot_control/flight_navigation.h
@@ -434,6 +434,8 @@ namespace aerial_robot_navigation
 
     virtual void updateLandCommand();
 
+    void updatePoseFromTrajectory();
+
     tf::Vector3 frameConversion(tf::Vector3 origin_val,  tf::Matrix3x3 r)
     {
       return r * origin_val;

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -690,70 +690,7 @@ void BaseNavigator::update()
   /* update the target pos and velocity */
   if (trajectory_mode_)
     {
-      if(getNaviState() == HOVER_STATE)
-        {
-          if (traj_generator_ptr_.get() == nullptr)
-            {
-              if (ros::Time::now().toSec() > trajectory_reset_time_)
-                {
-                  setTargetZeroVel();
-                  setTargetZeroAcc();
-
-                  setTargetZeroOmega();
-                  setTargetZeroAngAcc();
-
-                  trajectory_mode_ = false;
-
-                  ROS_INFO("[Flight nav] stop trajectory mode in POS-VEL mode");
-                }
-            }
-          else
-            {
-              // trajectory following mode
-              double t = ros::Time::now().toSec();
-
-              if (traj_generator_ptr_.get() != nullptr)
-                {
-                  double end_t = traj_generator_ptr_->getEndSetpoint().state.t;
-
-                  if (t > end_t)
-                    {
-                      ROS_INFO("[Nav] reach the end of trajectory");
-
-                      setTargetZeroVel();
-                      setTargetZeroAcc();
-
-                      setTargetZeroOmega();
-                      setTargetZeroAngAcc();
-
-                      trajectory_mode_ = false;
-
-                      traj_generator_ptr_.reset();
-                    }
-                  else
-                    {
-                      if (traj_generator_ptr_.get() != nullptr)
-                        {
-                          agi::QuadState target_state = traj_generator_ptr_->getState(t);
-                          setTargetPos(tf::Vector3(target_state.p(0), target_state.p(1), target_state.p(2)));
-                          setTargetVel(tf::Vector3(target_state.v(0), target_state.v(1), target_state.v(2)));
-                          setTargetAcc(tf::Vector3(target_state.a(0), target_state.a(1), target_state.a(2)));
-
-                          double target_yaw = target_state.getYaw();
-                          double target_omega_z = target_state.w(2);
-                          double target_ang_acc_z = target_state.tau(2);
-                          setTargetYaw(target_yaw);
-                          setTargetOmegaZ(target_omega_z);
-                          setTargetAngAccZ(target_ang_acc_z);
-
-                          tf::Vector3 curr_pos = estimator_->getPos(Frame::COG, estimate_mode_);
-                          double yaw_angle = estimator_->getState(State::YAW_COG, estimate_mode_)[0];
-                          ROS_INFO_THROTTLE(0.5, "[Nav] trajectory mode, target pos&yaw: [%f, %f, %f, %f], curr pos&yaw: [%f, %f, %f, %f]", target_state.p(0), target_state.p(1), target_state.p(2), target_yaw, curr_pos.x(), curr_pos.y(), curr_pos.z(), yaw_angle);
-                        }
-                    }
-                }
-            }
-        }
+      updatePoseFromTrajectory();
     }
   else
     {
@@ -1056,6 +993,88 @@ void BaseNavigator::generateNewTrajectory(geometry_msgs::PoseStamped pose)
     msg.poses.push_back(pose_stamp);
   }
   path_pub_.publish(msg);
+
+}
+
+void BaseNavigator::updatePoseFromTrajectory()
+{
+  if(getNaviState() != HOVER_STATE) return;
+
+  if (traj_generator_ptr_.get() == nullptr)
+    {
+      if (ros::Time::now().toSec() > trajectory_reset_time_)
+        {
+          setTargetZeroVel();
+          setTargetZeroAcc();
+
+          setTargetZeroOmega();
+          setTargetZeroAngAcc();
+
+          trajectory_mode_ = false;
+
+          ROS_INFO("[Flight nav] stop trajectory mode in POS-VEL mode");
+        }
+
+      return;
+    }
+
+
+  // trajectory following mode
+  double t = ros::Time::now().toSec();
+
+  // asynchronous with generateNewTrajectory
+  if (traj_generator_ptr_.get() == nullptr)
+    {
+      ROS_WARN("[Flight nav][Trajectory] terminate in trajectory mode since traj_generator_ptr_ is empty");
+      return;
+    }
+
+  double end_t = traj_generator_ptr_->getEndSetpoint().state.t;
+
+  // terminate if reach the end of trajectory
+  if (t > end_t)
+    {
+      ROS_INFO("[Nav] reach the end of trajectory");
+
+      setTargetZeroVel();
+      setTargetZeroAcc();
+
+      setTargetZeroOmega();
+      setTargetZeroAngAcc();
+
+      trajectory_mode_ = false;
+
+      traj_generator_ptr_.reset();
+
+      return;
+    }
+
+  // asynchronous with generateNewTrajectory
+  if (traj_generator_ptr_.get() == nullptr)
+    {
+      ROS_WARN("[Flight nav][Trajectory] terminate in trajectory mode since traj_generator_ptr_ is empty");
+      return;
+    }
+
+
+  // find the target pose at t from trajectory
+  agi::QuadState target_state = traj_generator_ptr_->getState(t);
+  setTargetPos(tf::Vector3(target_state.p(0), target_state.p(1), target_state.p(2)));
+  setTargetVel(tf::Vector3(target_state.v(0), target_state.v(1), target_state.v(2)));
+  setTargetAcc(tf::Vector3(target_state.a(0), target_state.a(1), target_state.a(2)));
+
+  double target_yaw = target_state.getYaw();
+  double target_omega_z = target_state.w(2);
+  double target_ang_acc_z = target_state.tau(2);
+  setTargetYaw(target_yaw);
+  setTargetOmegaZ(target_omega_z);
+  setTargetAngAccZ(target_ang_acc_z);
+
+  tf::Vector3 curr_pos = estimator_->getPos(Frame::COG, estimate_mode_);
+  double yaw_angle = estimator_->getState(State::YAW_COG, estimate_mode_)[0];
+  ROS_INFO_THROTTLE(0.5, "[Nav] trajectory mode, target pos&yaw: [%f, %f, %f, %f], curr pos&yaw: [%f, %f, %f, %f]", \
+                    target_state.p(0), target_state.p(1), target_state.p(2), target_yaw, \
+                    curr_pos.x(), curr_pos.y(), curr_pos.z(), yaw_angle);
 
 }
 

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -711,38 +711,46 @@ void BaseNavigator::update()
             {
               // trajectory following mode
               double t = ros::Time::now().toSec();
-              double end_t = traj_generator_ptr_->getEndSetpoint().state.t;
-              if (t > end_t)
+
+              if (traj_generator_ptr_.get() != nullptr)
                 {
-                  ROS_INFO("[Nav] reach the end of trajectory");
+                  double end_t = traj_generator_ptr_->getEndSetpoint().state.t;
 
-                  setTargetZeroVel();
-                  setTargetZeroAcc();
+                  if (t > end_t)
+                    {
+                      ROS_INFO("[Nav] reach the end of trajectory");
 
-                  setTargetZeroOmega();
-                  setTargetZeroAngAcc();
+                      setTargetZeroVel();
+                      setTargetZeroAcc();
 
-                   trajectory_mode_ = false;
+                      setTargetZeroOmega();
+                      setTargetZeroAngAcc();
 
-                  traj_generator_ptr_.reset();
-                }
-              else
-                {
-                  agi::QuadState target_state = traj_generator_ptr_->getState(t);
-                  setTargetPos(tf::Vector3(target_state.p(0), target_state.p(1), target_state.p(2)));
-                  setTargetVel(tf::Vector3(target_state.v(0), target_state.v(1), target_state.v(2)));
-                  setTargetAcc(tf::Vector3(target_state.a(0), target_state.a(1), target_state.a(2)));
+                      trajectory_mode_ = false;
 
-                  double target_yaw = target_state.getYaw();
-                  double target_omega_z = target_state.w(2);
-                  double target_ang_acc_z = target_state.tau(2);
-                  setTargetYaw(target_yaw);
-                  setTargetOmegaZ(target_omega_z);
-                  setTargetAngAccZ(target_ang_acc_z);
+                      traj_generator_ptr_.reset();
+                    }
+                  else
+                    {
+                      if (traj_generator_ptr_.get() != nullptr)
+                        {
+                          agi::QuadState target_state = traj_generator_ptr_->getState(t);
+                          setTargetPos(tf::Vector3(target_state.p(0), target_state.p(1), target_state.p(2)));
+                          setTargetVel(tf::Vector3(target_state.v(0), target_state.v(1), target_state.v(2)));
+                          setTargetAcc(tf::Vector3(target_state.a(0), target_state.a(1), target_state.a(2)));
 
-                  tf::Vector3 curr_pos = estimator_->getPos(Frame::COG, estimate_mode_);
-                  double yaw_angle = estimator_->getState(State::YAW_COG, estimate_mode_)[0];
-                  ROS_INFO_THROTTLE(0.5, "[Nav] trajectory mode, target pos&yaw: [%f, %f, %f, %f], curr pos&yaw: [%f, %f, %f, %f]", target_state.p(0), target_state.p(1), target_state.p(2), target_yaw, curr_pos.x(), curr_pos.y(), curr_pos.z(), yaw_angle);
+                          double target_yaw = target_state.getYaw();
+                          double target_omega_z = target_state.w(2);
+                          double target_ang_acc_z = target_state.tau(2);
+                          setTargetYaw(target_yaw);
+                          setTargetOmegaZ(target_omega_z);
+                          setTargetAngAccZ(target_ang_acc_z);
+
+                          tf::Vector3 curr_pos = estimator_->getPos(Frame::COG, estimate_mode_);
+                          double yaw_angle = estimator_->getState(State::YAW_COG, estimate_mode_)[0];
+                          ROS_INFO_THROTTLE(0.5, "[Nav] trajectory mode, target pos&yaw: [%f, %f, %f, %f], curr pos&yaw: [%f, %f, %f, %f]", target_state.p(0), target_state.p(1), target_state.p(2), target_yaw, curr_pos.x(), curr_pos.y(), curr_pos.z(), yaw_angle);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### What is this

The operation about trajectory generator is distributed several thread. To achieve the exclusive control, whether the pointer of trajectory generator is empty is checked every time. 

### Details

- The pointer of trajectory generator is empty is checked before using the related API. [Example](https://github.com/jsk-ros-pkg/jsk_aerial_robot/compare/master...tongtybj:aerial_robot:PR/navigation/trajectory_reset?expand=1#diff-9c1ce395efa7ef3a077e6e1471de383649423c7453dd7c227c41adf5fd490eb8R1026-R1032).


