### PR TITLE
[Spinal][In-house MD] Interface to comunicate with in-house motor driver.

### DIFF
--- a/aerial_robot_nerve/spinal/CMakeLists.txt
+++ b/aerial_robot_nerve/spinal/CMakeLists.txt
@@ -22,6 +22,7 @@ add_message_files(
   ServoInfo.msg
   BoardInfo.msg
   ServoState.msg
+  ServoExtendedState.msg
   ServoStates.msg
   ServoControlCmd.msg
   ServoTorqueCmd.msg

--- a/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7_v2/Src/main.c
+++ b/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7_v2/Src/main.c
@@ -45,6 +45,7 @@
 #include "battery_status/battery_status.h"
 
 #include "servo/servo.h"
+#include "servo/InHouseServo/in_house_servo.h"
 
 #include "state_estimate/state_estimate.h"
 #include "flight_control/flight_control.h"
@@ -127,7 +128,7 @@ BatteryStatus battery_status_;
 /* servo instance */
 DirectServo servo_;
 DShot dshot_;
-
+InHouse_Servo::Servo in_house_servo_;
 
 StateEstimate estimator_;
 FlightControl controller_;
@@ -268,6 +269,7 @@ int main(void)
   dshot_.initTelemetry(&huart6);
   controller_.init(&htim1, &htim4, &estimator_, &dshot_, &battery_status_, &nh_, &flightControlMutexHandle);
 #else
+  in_house_servo_.init(&hfdcan1, &canMsgMailHandle, &nh_, LED1_GPIO_Port, LED1_Pin);
   battery_status_.init(&hadc1, &nh_);
   estimator_.init(&imu_, &baro_, &gps_, &nh_);  // imu + baro + gps => att + alt + pos(xy)
   controller_.init(&htim1, &htim4, &estimator_, NULL, &battery_status_, &nh_, &flightControlMutexHandle);
@@ -1223,6 +1225,8 @@ void coreTaskFunc(void const * argument)
       gps_.update();
       estimator_.update();
       controller_.update();
+
+      in_house_servo_.update();
 
 #if !SERVO_FLAG && NERVE_COMM      
       Spine::update();

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_core.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_core.cpp
@@ -118,7 +118,14 @@ namespace CAN {
 
   void sendMessage(uint8_t device_id, uint8_t message_id, uint8_t slave_id, uint32_t dlc, uint8_t* data, uint32_t timeout)
   {
-    tx_header_.Identifier = (((device_id & ((1 << DEVICE_ID_LEN) - 1))  << (MESSAGE_ID_LEN + SLAVE_ID_LEN))) | ((message_id & ((1 << MESSAGE_ID_LEN) - 1)) << SLAVE_ID_LEN) | (slave_id & ((1 << SLAVE_ID_LEN) - 1));
+    uint32_t identifier = (((device_id & ((1 << DEVICE_ID_LEN) - 1))  << (MESSAGE_ID_LEN + SLAVE_ID_LEN))) | ((message_id & ((1 << MESSAGE_ID_LEN) - 1)) << SLAVE_ID_LEN) | (slave_id & ((1 << SLAVE_ID_LEN) - 1));
+
+    sendMessage(identifier, dlc, data, timeout);
+  }
+
+  void sendMessage(uint32_t identifier, uint32_t dlc, uint8_t* data, uint32_t timeout)
+  {
+    tx_header_.Identifier = identifier;
 
     if (dlc <= 8) { // calssic  model
       tx_header_.FDFormat = FDCAN_CLASSIC_CAN;

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_core.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_core.h
@@ -31,6 +31,10 @@ namespace CAN {
     HAL_CAN_ActivateNotification(getHcanInstance(), CAN_IT_RX_FIFO1_MSG_PENDING);
   }
 
+  inline uint32_t getIdentifier(CAN_RxHeaderTypeDef rx_header) {
+    return rx_header.StdId;
+  }
+
   inline uint8_t getDeviceId(CAN_RxHeaderTypeDef rx_header) {
     return static_cast<uint8_t>(((rx_header.StdId) >> (MESSAGE_ID_LEN + SLAVE_ID_LEN)) & ((1 << DEVICE_ID_LEN) - 1));
   }
@@ -59,12 +63,17 @@ namespace CAN {
 namespace CAN {
   void init(FDCAN_HandleTypeDef* hfdcan);
   FDCAN_HandleTypeDef* getHcanInstance();
+  void sendMessage(uint32_t identifier, uint32_t DLC, uint8_t* data, uint32_t timeout);
   void sendMessage(uint8_t device_id, uint8_t message_id, uint8_t slave_id, uint32_t DLC, uint8_t* data, uint32_t timeout);
 
   inline void CAN_START()
   {
     HAL_FDCAN_Start(getHcanInstance());
     HAL_FDCAN_ActivateNotification(getHcanInstance(), FDCAN_IT_RX_FIFO0_NEW_MESSAGE, 0);
+  }
+
+  inline uint32_t getIdentifier(FDCAN_RxHeaderTypeDef rx_header) {
+    return rx_header.Identifier;
   }
 
   inline uint8_t getDeviceId(FDCAN_RxHeaderTypeDef rx_header) {

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_device.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_device.h
@@ -31,4 +31,18 @@ public:
 };
 
 
+
+class CANDirectDevice
+{
+protected:
+	uint32_t m_identifier;
+public:
+	CANDirectDevice(){}
+	CANDirectDevice(uint32_t identifier):m_identifier(identifier){}
+	void sendMessage(uint32_t identifier, uint32_t dlc, uint8_t* data, uint32_t timeout){CAN::sendMessage(identifier, dlc, data, timeout);}
+	virtual void sendData() = 0;
+	virtual void receiveDataCallback(uint32_t identifier, uint32_t dlc, uint8_t* data) = 0;
+};
+
+
 #endif /* APPLICATION_CAN_CAN_DEVICE_H_ */

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_device_manager.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_device_manager.h
@@ -37,6 +37,7 @@ namespace CANDeviceManager
   void init(FDCAN_HandleTypeDef* hcan, GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
 #endif
   void addDevice(CANDevice& device);
+  void addDirectDevice(CANDirectDevice* device);
   void useRTOS(osMailQId* handle);
   void tick(int cycle /* ms */);
   bool connected();

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/configs/STM32H7_v2/config.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/configs/STM32H7_v2/config.h
@@ -47,7 +47,7 @@
 //2.1.3 GPS Sensor
 #define GPS_FLAG 1
 //2.1.3 Direct Servo Control
-#define SERVO_FLAG 1
+#define SERVO_FLAG 0
 
 
 //2.2 State Estimate

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/InHouseServo/in_house_servo.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/InHouseServo/in_house_servo.cpp
@@ -1,0 +1,118 @@
+/**
+******************************************************************************
+* File Name          : in_house_servo.cpp
+* Description        : interface for in-house servo
+ ------------------------------------------------------------------*/
+
+#include "in_house_servo.h"
+
+using namespace InHouse_Servo;
+
+Servo::Servo():
+  servo_state_pub_("servo/states", &servo_state_msg_),
+  servo_cmd_sub_("servo/target_states", &Servo::servoControlCallback, this),
+  servo_torque_ctrl_sub_("servo/torque_enable", &Servo::servoTorqueControlCallback,this)
+{
+  servo_last_pub_time_ = 0;
+  servo_last_ctrl_time_ = 0;  
+}
+
+void Servo::init(CAN_GeranlHandleTypeDef* hcan, osMailQId* handle, ros::NodeHandle* nh, GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+    /* CAN */
+    CANDeviceManager::init(hcan, GPIOx, GPIO_Pin);
+    CANDeviceManager::useRTOS(handle);
+    CANDeviceManager::addDirectDevice(this);
+
+    /* ros */
+    nh_ = nh;
+    nh_->advertise(servo_state_pub_);
+    nh_->subscribe(servo_cmd_sub_);
+    nh_->subscribe(servo_torque_ctrl_sub_);
+
+    CANDeviceManager::CAN_START();
+  }
+
+void Servo::sendData()
+{
+  sendMessage(canTxId, 8, inst_data_, 0);
+  memset(inst_data_, 0, sizeof(inst_data_));//clear instruction
+}
+
+void Servo::receiveDataCallback(uint32_t identifier, uint32_t dlc, uint8_t* data)
+{
+  // Decode current position
+  current_pos_i_ = (static_cast<int16_t>(data[0]) << 8)  |
+    static_cast<int16_t>(data[1]);
+  current_pos_f_ = (current_pos_i_ / 4096.0f) * (2.0f * static_cast<float>(M_PI));
+
+  // Decode current rpm
+  current_rpm_i_ = (static_cast<int16_t>(data[2]) << 8)  |
+    static_cast<int16_t>(data[3]);
+    
+  // Decode current power
+  current_power_i_ = (static_cast<int16_t>(data[4]) << 8) |
+    static_cast<int16_t>(data[5]);
+  current_power_f_ = current_power_i_ / 10.0f;
+    
+  // Decode current motor state
+  current_state_ = data[6];
+
+
+  //set date to ros_msg
+  servo_state_msg_.index = identifier;
+  servo_state_msg_.angle = current_pos_i_;
+  servo_state_msg_.rpm = current_rpm_i_;
+  servo_state_msg_.power = current_power_i_;
+  servo_state_msg_.state = current_state_;
+}
+
+void Servo::update(void)
+{
+  CANDeviceManager::tick(1);
+  uint32_t now_time = HAL_GetTick();
+
+  /* control */
+  if( now_time - servo_last_ctrl_time_ >= SERVO_CTRL_INTERVAL)
+    {
+      sendData();
+      servo_last_ctrl_time_ = now_time;
+    }
+
+  /* ros publish */
+
+  if( now_time - servo_last_pub_time_ >= SERVO_PUB_INTERVAL)
+    {
+      /* send servo */
+      servo_state_pub_.publish(&servo_state_msg_);
+      servo_last_pub_time_ = now_time;
+    }
+}
+
+void Servo::servoControlCallback(const spinal::ServoControlCmd& control_msg)
+{
+  for (unsigned int i = 0; i < control_msg.index_length; i++) {
+    uint8_t index = control_msg.index[i];
+    if(index == servo_id_)
+      {
+        int16_t goal_pos = (control_msg.angles[i]);
+        inst_data_[0] =0x03;
+        inst_data_[1] = (uint8_t)((goal_pos >> 8) & 0xFF);
+        inst_data_[2] = (uint8_t)(goal_pos & 0xFF);
+      }
+  }
+}
+
+void Servo::servoTorqueControlCallback(const spinal::ServoTorqueCmd& control_msg)
+{
+  for (unsigned int i = 0; i < control_msg.index_length; i++) {
+    uint8_t index = control_msg.index[i];
+    if(index == servo_id_)
+      {
+        if(control_msg.torque_enable[i])
+          inst_data_[0] = 0x01;
+        else
+          inst_data_[0] = 0x02;
+      }
+  }
+}

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/InHouseServo/in_house_servo.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/InHouseServo/in_house_servo.h
@@ -1,0 +1,75 @@
+/**
+  ******************************************************************************
+  * File Name          : in_house_servo.hpp
+  * Description        : interface for in-house servo
+ Includes ------------------------------------------------------------------*/
+
+#ifndef __IN_HOUSE_SERVO_H
+#define __IN_HOUSE_SERVO_H
+
+#include <config.h>
+#include <ros.h>
+#include <CAN/can_device_manager.h>
+#include <spinal/ServoExtendedState.h>
+#include <spinal/ServoControlCmd.h>
+#include <spinal/ServoTorqueCmd.h>
+
+#include "math/AP_Math.h"
+
+/* RTOS */
+#include "cmsis_os.h"
+
+#ifdef STM32F7
+using CAN_GeranlHandleTypeDef = CAN_HandleTypeDef;
+#endif
+
+#ifdef STM32H7
+using CAN_GeranlHandleTypeDef = FDCAN_HandleTypeDef;
+#endif
+
+namespace InHouse_Servo
+{
+  class Servo : public CANDirectDevice
+  {
+  public:
+    Servo();
+    ~Servo(){}
+
+    void init(CAN_GeranlHandleTypeDef* hcan, osMailQId* handle, ros::NodeHandle* nh, GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+
+    void update(void);
+    void servoControlCallback(const spinal::ServoControlCmd& control_msg);
+    void servoTorqueControlCallback(const spinal::ServoTorqueCmd& control_msg);
+
+    void sendData() override;
+    void receiveDataCallback(uint32_t identifier, uint32_t dlc, uint8_t* data) override;
+
+  private:
+    ros::NodeHandle* nh_;
+    ros::Publisher servo_state_pub_;
+    ros::Subscriber<spinal::ServoControlCmd, Servo> servo_cmd_sub_;
+    ros::Subscriber<spinal::ServoTorqueCmd, Servo> servo_torque_ctrl_sub_;
+    spinal::ServoExtendedState servo_state_msg_;
+
+    uint32_t servo_last_pub_time_;
+    uint32_t servo_last_ctrl_time_;
+
+    //motor states
+    int16_t current_pos_i_;
+    float current_pos_f_;
+    int16_t current_rpm_i_;
+    int16_t current_power_i_;
+    float current_power_f_;
+    uint8_t current_state_;
+
+    uint8_t inst_data_[8];
+
+    
+    // temporary constants to communicate with in-house servo
+    static const uint8_t servo_id_ = 1;
+    static const uint32_t canTxId = 0x01;
+    static constexpr int32_t SERVO_PUB_INTERVAL = 10; // [ms]
+    static constexpr int32_t SERVO_CTRL_INTERVAL = 20; // [ms]
+  };
+}
+#endif

--- a/aerial_robot_nerve/spinal/msg/ServoExtendedState.msg
+++ b/aerial_robot_nerve/spinal/msg/ServoExtendedState.msg
@@ -1,0 +1,17 @@
+uint32 index #from 0
+int16 angle # 15bit[-32768, 32767]
+int16 rpm # 15bit[-32768, 32767]
+int16 power # power
+uint8 state # state
+
+uint8 IDLE = 0
+uint8 ALIGNMENT = 2
+uint8 START = 4
+uint8 RUN = 6
+uint8 STOP = 8
+uint8 FAULT_NOW = 10
+uint8 FAULT_OVER = 11
+uint8 ICLWAIT = 12
+uint8 CHARGE_BOOT_CAP = 16
+uint8 OFFSET_CALIB = 17
+uint8 SWITCH_OVER = 19


### PR DESCRIPTION
### What is this

This provides an interface by CAN to communicate with the in-house motor driver.
Currently, it includes simple instructions such as torque on/off, goal angle setting, and polling for servo status.
### TODO
Since this interface is temporary, it works independently from [servo/servo.cpp](https://github.com/jsk-ros-pkg/jsk_aerial_robot/blob/master/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/servo.cpp). Therefore, it should be works as well as the [dynamixel interfaces](https://github.com/jsk-ros-pkg/jsk_aerial_robot/tree/master/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/Dynamixel) in future.
Additionally, this PR should be compatible with other PR related to direct CAN devices such as #643 and #645 .