### PR TITLE
[Rostest][Timeout] increase the delay for sending task start trigger for mini_quadrotor and hydrus_xi

### DIFF
--- a/robots/hydrus_xi/test/hydrus_xi_hex_branch_control.test
+++ b/robots/hydrus_xi/test/hydrus_xi_hex_branch_control.test
@@ -23,6 +23,6 @@
          yaw_thresh: 0.02
     </rosparam>
   </test>
-  <node name="task_task_trigger" pkg="rostopic" type="rostopic" args="pub -1 /task_start std_msgs/Empty" launch-prefix="bash -c 'sleep 2.0; $0 $@' "/>
+  <node name="task_task_trigger" pkg="rostopic" type="rostopic" args="pub -1 /task_start std_msgs/Empty" launch-prefix="bash -c 'sleep 5.0; $0 $@' "/>
 
 </launch>

--- a/robots/mini_quadrotor/test/flight_control.test
+++ b/robots/mini_quadrotor/test/flight_control.test
@@ -14,13 +14,13 @@
   </include>
 
   <!-- test codes -->
-  <test test-name="control_test" pkg="aerial_robot_base" type="hovering_check.py"  name="control_test"  ns="$(arg robot_ns)" time-limit="30" retry="2">
+  <test test-name="control_test" pkg="aerial_robot_base" type="hovering_check.py"  name="control_test"  ns="$(arg robot_ns)" time-limit="50" retry="2">
     <rosparam>
       waypoint:
         waypoints: [[0, 0, 1.6]]
     </rosparam>
   </test>
-  <node name="task_task_trigger" pkg="rostopic" type="rostopic" args="pub -1 /task_start std_msgs/Empty" launch-prefix="bash -c 'sleep 2.0; $0 $@' "/>
+  <node name="task_task_trigger" pkg="rostopic" type="rostopic" args="pub -1 /task_start std_msgs/Empty" launch-prefix="bash -c 'sleep 5.0; $0 $@' "/>
 
 
 </launch>


### PR DESCRIPTION
### What is this

The privous delay (i.e. 2sec) for sending task start topic is too shut for the gazebo initialization. Therefore increase it to 5 sec.

### Details

Related issue: https://github.com/jsk-ros-pkg/jsk_aerial_robot/pull/671#issuecomment-2660897536