### PR TITLE
Explicitly deconstructing

### DIFF
--- a/aerial_robot_base/src/aerial_robot_base.cpp
+++ b/aerial_robot_base/src/aerial_robot_base.cpp
@@ -83,6 +83,7 @@ AerialRobotBase::~AerialRobotBase()
   // what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
   main_timer_.stop();
   main_loop_spinner_.stop();
+  callback_spinner_.stop();
 }
 
 void AerialRobotBase::mainFunc(const ros::TimerEvent & e)


### PR DESCRIPTION
### What is this

Added explicit stop() call of callback_spinner_ in deconstructor of AerialRobotBase class as done for main_loop_spinner_

### Details

Please explain the contribution of this PR in detail.

- PR/add_stop_decl: added stop() call in deconstructor ~AerialRobotBase()