### PR TITLE
Missing return statement in logic for altitude sensor

### DIFF
--- a/aerial_robot_estimation/src/sensor/altitude.cpp
+++ b/aerial_robot_estimation/src/sensor/altitude.cpp
@@ -541,7 +541,8 @@ namespace sensor_plugin
                       return true;
                     }
                 }
-              break;
+              //break;
+              return false;
             case MAX_EXCEED:
               /* the sensor value is below the max value ath the MAX_EXCEED state */
               /*we first turn back to ABNORMAL mode to verify the validity of the value */


### PR DESCRIPTION
### What is this

The cmake build process gives the following warning:
"jsk_aerial_robot/aerial_robot_estimation/src/sensor/altitude.cpp:583:5: warning: control reaches end of non-void function [-Wreturn-type]"

Which means there is a logical path in the function "bool terrainProcess()" where there is no return statement.

### Details

Added a default "return false" for the ABNORMAL case where the recovering process didn't succeed and the altitude measurement is faulty.

### TODO

Please check if my reasoning is correct!