### PR TITLE
[Spinal] update the cube_ide.sh to launch stm32H7_v2 for spinal v4.1

### DIFF
--- a/aerial_robot_nerve/spinal/bin/cube_ide.sh
+++ b/aerial_robot_nerve/spinal/bin/cube_ide.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-if [ "$1" = "" ]
-then
-    echo -e "\e[33m No argument! please select board type from ['stm32F7', 'stm32H7'], such as: \n \$ rosrun spinal cube_ide.sh stm32F7 \e[m"
+if [ "$1" = "" ]; then
+    echo -e "\e[33m No argument! Please select a board type from ['stm32F7', 'stm32H7', 'stm32H7_v2'], such as: \n \$ rosrun spinal cube_ide.sh stm32F7 \e[m"
     exit
-elif [ $1 = "stm32F7" -o $1 = "stm32H7" ]
-then
+elif [ "$1" = "stm32F7" ] || [ "$1" = "stm32H7" ] || [ "$1" = "stm32H7_v2" ]; then
     stm32cubeide `rospack find spinal`/mcu_project/boards/$1/STM32CubeIDE/.project
 else
-    echo -e "\e[33m We do not support board type of $1, please select board type from ['stm32F7', 'stm32H7'], such as: \n \$ rosrun spinal cube_ide.sh stm32F7 \e[m"
+    echo -e "\e[33m We do not support board type '$1'. Please select a board type from ['stm32F7', 'stm32H7', 'stm32H7_v2'], such as: \n \$ rosrun spinal cube_ide.sh stm32F7 \e[m"
 fi


### PR DESCRIPTION
### What is this

The latest version of spinal firmware 4.1 has not been updated in cube_ide.sh, so I update it.

### Details

To use it:
`rosrun spinal cube_ide.sh stm32H7_v2`

Just for clarification: after the PR #630, we should use stm32H7_v2 for Spinal v4.1, right? The newly supported function includes the DShot protocol and direct servo control. Is my understanding correct? @sugihara-16 