### PR TITLE
[aerial_robot_model]: Change the gravity const to Tokyo value.

### DIFF
--- a/aerial_robot_model/src/model/base_model/robot_model.cpp
+++ b/aerial_robot_model/src/model/base_model/robot_model.cpp
@@ -20,10 +20,12 @@ namespace aerial_robot_model {
     if (init_with_rosparam)
       getParamFromRos();
 
+    // the gravity constant at Tokyo.
+    // Ref: Fundamental Gravity Value in Japan https://www.jstage.jst.go.jp/article/sokuchi1954/16/3/16_3_169/_pdf/-char/en
     gravity_.resize(6);
-    gravity_ <<  0, 0, 9.80665, 0, 0, 0;
+    gravity_ <<  0, 0, 9.798015, 0, 0, 0;
     gravity_3d_.resize(3);
-    gravity_3d_ << 0, 0, 9.80665;
+    gravity_3d_ << 0, 0, 9.798015;
 
     kinematicsInit();
     stabilityInit();


### PR DESCRIPTION
### What is this

Change the gravity constant in our code to the value at Tokyo for better accuracy.

9.80665 -> 9.798015

Ref: Fundamental Gravity Value in Japan 
Link: https://www.jstage.jst.go.jp/article/sokuchi1954/16/3/16_3_169/_pdf/-char/en