### PR TITLE
[estimation] publish imu data from spinal w.r.t lidar_imu frame

### DIFF
--- a/aerial_robot_estimation/CMakeLists.txt
+++ b/aerial_robot_estimation/CMakeLists.txt
@@ -51,7 +51,8 @@ add_library(sensor_pluginlib
   src/sensor/mocap.cpp
   src/sensor/gps.cpp
   src/sensor/imu.cpp
-  src/sensor/plane_detection.cpp)
+  src/sensor/plane_detection.cpp
+  src/sensor/lio.cpp)
 
 target_link_libraries(sensor_pluginlib ${catkin_LIBRARIES})
 add_dependencies(sensor_pluginlib aerial_robot_msgs_generate_messages_cpp spinal_generate_messages_cpp)

--- a/aerial_robot_estimation/include/aerial_robot_estimation/sensor/lio.h
+++ b/aerial_robot_estimation/include/aerial_robot_estimation/sensor/lio.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <aerial_robot_estimation/sensor/base_plugin.h>
+#include <sensor_msgs/Imu.h>
+#include <spinal/Imu.h>
+
+
+namespace sensor_plugin
+{
+  class LidarInertialOdometry : public SensorBase
+  {
+  public:
+    LidarInertialOdometry(){};
+    ~LidarInertialOdometry(){};
+
+    void initialize(ros::NodeHandle nh,
+                    boost::shared_ptr<aerial_robot_model::RobotModel> robot_model,
+                    boost::shared_ptr<aerial_robot_estimation::StateEstimator> estimator,
+                    string sensor_name, int index) override;
+
+
+  private:
+    ros::Subscriber imu_sub_;
+    ros::Publisher lidar_imu_pub_;
+
+    std::string lidar_frame_;
+
+    void ImuCallback(const spinal::ImuConstPtr& imu_msg);
+  };
+};
+

--- a/aerial_robot_estimation/include/aerial_robot_estimation/state_estimation.h
+++ b/aerial_robot_estimation/include/aerial_robot_estimation/state_estimation.h
@@ -441,6 +441,7 @@ namespace aerial_robot_estimation
     }
 
     inline uint8_t getUnhealthLevel() { return unhealth_level_; }
+    std::string getTFPrefix() {return tf_prefix_;}
 
     const vector<boost::shared_ptr<sensor_plugin::SensorBase> >& getImuHandlers() const { return imu_handlers_;}
     const vector<boost::shared_ptr<sensor_plugin::SensorBase> >& getAltHandlers() const { return alt_handlers_;}

--- a/aerial_robot_estimation/include/aerial_robot_estimation/state_estimation.h
+++ b/aerial_robot_estimation/include/aerial_robot_estimation/state_estimation.h
@@ -470,6 +470,7 @@ namespace aerial_robot_estimation
     vector<boost::shared_ptr<sensor_plugin::SensorBase> > vo_handlers_;
     vector<boost::shared_ptr<sensor_plugin::SensorBase> > gps_handlers_;
     vector<boost::shared_ptr<sensor_plugin::SensorBase> > plane_detection_handlers_;
+    vector<boost::shared_ptr<sensor_plugin::SensorBase> > lio_handlers_;
 
     /* mutex */
     boost::mutex state_mutex_;

--- a/aerial_robot_estimation/plugins/sensor_plugins.xml
+++ b/aerial_robot_estimation/plugins/sensor_plugins.xml
@@ -28,4 +28,8 @@
     <description>Plane Detection sensor plugin.</description>
   </class>
 
+  <class name="sensor_plugin/lio" type="sensor_plugin::LidarInertialOdometry" base_class_type="sensor_plugin::SensorBase">
+    <description>Lidar Inertial Odometry sensor plugin.</description>
+  </class>
+
 </library>

--- a/aerial_robot_estimation/src/sensor/imu.cpp
+++ b/aerial_robot_estimation/src/sensor/imu.cpp
@@ -422,6 +422,7 @@ namespace sensor_plugin
   {
     sensor_msgs::Imu imu_data;
     imu_data.header.stamp = imu_stamp_;
+    imu_data.header.frame_id = tf::resolve(estimator_->getTFPrefix(), robot_model_->getBaselinkName());
     tf::Quaternion q;
     raw_rot_.getRotation(q);
     tf::quaternionTFToMsg(q, imu_data.orientation);

--- a/aerial_robot_estimation/src/sensor/lio.cpp
+++ b/aerial_robot_estimation/src/sensor/lio.cpp
@@ -31,8 +31,8 @@ namespace sensor_plugin
 
     for(int i = 0; i < 3; i++)
       {
-        acc_b[i] = imu_msg->acc_data[i];
-        gyro_b[i] = imu_msg->gyro_data[i];
+        acc_b[i] = imu_msg->acc[i];
+        gyro_b[i] = imu_msg->gyro[i];
       }
 
     tf::Transform lidar2baselink_tf;

--- a/aerial_robot_estimation/src/sensor/lio.cpp
+++ b/aerial_robot_estimation/src/sensor/lio.cpp
@@ -1,0 +1,56 @@
+#include <aerial_robot_estimation/sensor/lio.h>
+
+namespace sensor_plugin
+{
+  void LidarInertialOdometry::initialize(ros::NodeHandle nh,
+                                         boost::shared_ptr<aerial_robot_model::RobotModel> robot_model,
+                                         boost::shared_ptr<aerial_robot_estimation::StateEstimator> estimator,
+                                         string sensor_name, int index)
+  {
+    SensorBase::initialize(nh, robot_model, estimator, sensor_name, index);
+
+    std::string topic_name;
+    getParam<std::string>("imu_topic_name", topic_name, std::string("imu"));
+    imu_sub_ = nh_.subscribe<spinal::Imu>(topic_name, 10, &LidarInertialOdometry::ImuCallback, this);
+
+    getParam<std::string>("lidar_imu_topic_name", topic_name, std::string("livox/imu_spinal"));
+    lidar_imu_pub_ = nh_.advertise<sensor_msgs::Imu>(topic_name, 1);
+    getParam<std::string>("lidar_frame", lidar_frame_, std::string("lidar_imu"));
+  }
+
+  void LidarInertialOdometry::ImuCallback(const spinal::ImuConstPtr& imu_msg)
+  {
+    if(!robot_model_->initialized()) return;
+
+    ros::Time imu_stamp = imu_msg->stamp;
+
+    tf::Vector3 acc_b;
+    tf::Vector3 gyro_b;
+    tf::Vector3 acc_lidar;
+    tf::Vector3 gyro_lidar;
+
+    for(int i = 0; i < 3; i++)
+      {
+        acc_b[i] = imu_msg->acc_data[i];
+        gyro_b[i] = imu_msg->gyro_data[i];
+      }
+
+    tf::Transform lidar2baselink_tf;
+    auto seg_tf_map = robot_model_->getSegmentsTf();
+    tf::transformKDLToTF(seg_tf_map.at(lidar_frame_).Inverse() * seg_tf_map.at(robot_model_->getBaselinkName()), lidar2baselink_tf);
+
+    acc_lidar = lidar2baselink_tf.getBasis() * acc_b / robot_model_->getGravity()(2);
+    gyro_lidar = lidar2baselink_tf.getBasis() * gyro_b;
+
+    sensor_msgs::Imu imu_ros_converted_msg;
+    imu_ros_converted_msg.header.stamp = imu_msg->stamp;
+    tf::vector3TFToMsg(gyro_lidar, imu_ros_converted_msg.angular_velocity);
+    tf::vector3TFToMsg(acc_lidar, imu_ros_converted_msg.linear_acceleration);
+    lidar_imu_pub_.publish(imu_ros_converted_msg);
+  }
+};
+
+/* plugin registration */
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(sensor_plugin::LidarInertialOdometry, sensor_plugin::SensorBase);
+

--- a/aerial_robot_estimation/src/state_estimation.cpp
+++ b/aerial_robot_estimation/src/state_estimation.cpp
@@ -330,6 +330,12 @@ void StateEstimator::rosParamInit()
               sensor_index.back() = plane_detection_handlers_.size();
             }
 
+          if(name.find("lio") != std::string::npos)
+            {
+              lio_handlers_.push_back(sensors_.back());
+              sensor_index.back() = lio_handlers_.size();
+            }
+
 
           sensors_.back()->initialize(nh_, robot_model_, shared_from_this(), name, sensor_index.back());
           break;


### PR DESCRIPTION
### What is this
Publish imu data from spinal w.r.t lidar_imu frame.

### Details
- Added new sensor_plugin named lio.
- gyro and acc data of spinal is published w.r.t lidar_imu frame using robot model with the same timestamp (but delayed).