### PR TITLE
[Estimation] explicitly add dependency of aerial_robot_estimation for sensor_pluginlib

### DIFF
--- a/aerial_robot_estimation/CMakeLists.txt
+++ b/aerial_robot_estimation/CMakeLists.txt
@@ -53,7 +53,7 @@ add_library(sensor_pluginlib
   src/sensor/imu.cpp
   src/sensor/plane_detection.cpp)
 
-target_link_libraries(sensor_pluginlib ${catkin_LIBRARIES})
+target_link_libraries(sensor_pluginlib aerial_robot_estimation ${catkin_LIBRARIES})
 add_dependencies(sensor_pluginlib aerial_robot_msgs_generate_messages_cpp spinal_generate_messages_cpp)
 
 ### kalman filter plugins


### PR DESCRIPTION
### What is this

Explicitly add dependency of aerial_robot_estimation for sensor_pluginlib

### Details

Several sensor plugins use the API of  state_estimation. For example:
```
chou@chou-ThinkPad-P14s-Gen-4:~/ros/jsk_aerial_robot/src/jsk_aerial_robot/aerial_robot_estimation$ grep "setOrientationWxB" * -r
include/aerial_robot_estimation/state_estimation.h:    void setOrientationWxB(int frame, int estimate_mode, tf::Vector3 v);
src/state_estimation.cpp:void StateEstimator::setOrientationWxB(int frame, int estimate_mode, tf::Vector3 v)
src/sensor/vo.cpp:        estimator_->setOrientationWxB(Frame::BASELINK, EGOMOTION_ESTIMATE, wx_b);
src/sensor/vo.cpp:        estimator_->setOrientationWxB(Frame::COG, EGOMOTION_ESTIMATE, wx_c);
src/sensor/mocap.cpp:          estimator_->setOrientationWxB(Frame::BASELINK, EXPERIMENT_ESTIMATE, wx_b);
src/sensor/mocap.cpp:          estimator_->setOrientationWxB(Frame::COG, EXPERIMENT_ESTIMATE, wx_c);
```

This can cause following build error in other package:
```
/usr/bin/ld: /home/chou/ros/jsk_aerial_robot/devel/.private/aerial_robot_estimation/lib/libsensor_pluginlib.so: undefined reference to `aerial_robot_estimation::StateEstimator::setOrientationWzB(int, int, tf::Vector3)'
/usr/bin/ld: /home/chou/ros/jsk_aerial_robot/devel/.private/aerial_robot_estimation/lib/libsensor_pluginlib.so: undefined reference to `aerial_robot_estimation::StateEstimator::setOrientationWxB(int, int, tf::Vector3)'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/outdoor_initial_pose_guess.dir/build.make:141: /home/chou/ros/daikin_markerless_ws/devel/.private/plant_localization/lib/plant_localization/outdoor_initial_pose_guess] Error 1
make[1]: *** [CMakeFiles/Makefile2:3566: CMakeFiles/outdoor_initial_pose_guess.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```