### PR TITLE
[Spinal] Enable PWM Test for aerial robots with neuron

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
@@ -211,16 +211,18 @@ void AttitudeController::pwmsControl(void)
 
   /* nerve comm type */
 #if NERVE_COMM
+  motor_number_ = Spine::getSlaveNum();
   for(int i = 0; i < motor_number_; i++) {
-#if MOTOR_TEST
+// #if MOTOR_TEST
 
-    if (i == (HAL_GetTick() / 2000) % motor_number_)
-      Spine::setMotorPwm(200, i);
-    else
-      Spine::setMotorPwm(0, i);
-#else
+//     if (i == (HAL_GetTick() / 2000) % motor_number_)
+//       Spine::setMotorPwm(200, i);
+//     else
+//       Spine::setMotorPwm(0, i);
+// #else
+//     Spine::setMotorPwm(target_pwm_[i] * 2000 - 1000, i);
+// #endif
     Spine::setMotorPwm(target_pwm_[i] * 2000 - 1000, i);
-#endif
   }
 #endif
 

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
@@ -64,7 +64,7 @@
 #define CONTROL_FEEDBACK_STATE_PUB_INTERVAL 25
 #define PWM_PUB_INTERVAL 100 //100ms
 
-#define MOTOR_TEST 0
+//#define MOTOR_TEST 0
 
 enum AXIS {
   X = 0,


### PR DESCRIPTION
### What is this

- Enable PWM Test for aerial robots with neuron
- Allow sending PWM individually without Pwm_flag (needed for the robots like Hugmy that send PWM to non-motor devices during flight)
- Add fail-safe mechanism


### Details

@sugihara-16  previously suggested adding motor number of the aerial robot in pwmTestCallback, but since Spinal is informed of the motor number at the time of arming, it is implemented this way.