### PR TITLE
[Spinal][Servo][Dynamixel] fix the bug about the command sending process for  goal position

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/drivers/Dynamixel/dynamixel_serial.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/drivers/Dynamixel/dynamixel_serial.cpp
@@ -282,13 +282,7 @@ void DynamixelSerial::update()
     if (set_pos_tick_ == 0) set_pos_tick_ = current_time + SET_POS_OFFSET; // init
     else set_pos_tick_ = current_time;
 
-    if (ttl_rs485_mixed_ != 0) {
-      for (unsigned int i = 0; i < servo_num_; ++i) {
-        instruction_buffer_.push(std::make_pair(INST_SET_GOAL_POS, i));
-      }
-    } else {
-      instruction_buffer_.push(std::make_pair(INST_SET_GOAL_POS, 0));
-    }
+    instruction_buffer_.push(std::make_pair(INST_SET_GOAL_POS, 0));
   }
 
   /* read servo position(angle) */


### PR DESCRIPTION
### What is this

Since the command of `set_goal_pos` does not require the return packet, so use sync mode for any situations (either )

### Details

- No matter whether `ttl_rs485_mixed` is activated, the command of `set_goal_pos`  use `cmdSyncWriteGoalPosition();`: https://github.com/tongtybj/aerial_robot/blob/c13027256db14e9e88dd502dbde99ffb024a6b74/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/drivers/Dynamixel/dynamixel_serial.cpp#L372
- Thus, following process is redundant and consume the bandwidth:
```bash
for (unsigned int i = 0; i < servo_num_; ++i) {
        instruction_buffer_.push(std::make_pair(INST_SET_GOAL_POS, i));
      }
```

- Related PR: https://github.com/sugihara-16/aerial_robot/pull/15
