### PR TITLE
[WIP] change msg type of rpy gain from int16 to uint16

### DIFF
--- a/aerial_robot_nerve/spinal/msg/RollPitchYawTerm.msg
+++ b/aerial_robot_nerve/spinal/msg/RollPitchYawTerm.msg
@@ -1,14 +1,14 @@
 #gain: only roll, pitch, yaw_d (throttle and yaw pi is calculated in PC side)
 
 # roll
-int16 roll_p
-int16 roll_i
-int16 roll_d
+uint16 roll_p
+uint16 roll_i
+uint16 roll_d
 
 # pitch
-int16 pitch_p
-int16 pitch_i
-int16 pitch_d
+uint16 pitch_p
+uint16 pitch_i
+uint16 pitch_d
 
 # yaw
-int16 yaw_d
+uint16 yaw_d


### PR DESCRIPTION
### What is this
change msg type of rpy gain from int16 to uint16

### Details

Currently, the upper limit of the RPY gain is 32,767 (≤ 2¹⁵ = 32,768, int16).
Since negative values are never used, we can change the message type to uint16, which increases the upper limit to 65,535.