### PR TITLE
[Spinal][IMU][MAG][ICM20948] Refactor the polling process of internal magnetometer AK09916

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/sensors/imu/drivers/icm20948/icm_20948.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/sensors/imu/drivers/icm20948/icm_20948.h
@@ -299,8 +299,5 @@ private:
 
   void readSingleAk09916(uint8_t reg);
   void writeSingleAk09916(uint8_t reg, uint8_t val);
-
-  void readMultipleAk09916(uint8_t reg);
-
 };
 #endif


### PR DESCRIPTION
### What is this

Refactor the polling process.  The old process used the wrong delay func, and the update rate of magnetometer was much less than the expected one (100Hz -> ~20Hz)

### Details

- The usage of HAL_Delay() in FreeRTOS system is forbidden: https://github.com/jsk-ros-pkg/jsk_aerial_robot/blob/1.3.6/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/sensors/imu/drivers/icm20948/icm_20948.cpp#L509. Reason 1: `HAL_Delay()` conflicts with the task scheduler. `osDelay()` is recommended instead; Reason 2: the `coretaskFunc` in which the about data polling process executed is running at 1000Hz, so `HAL_Delay(1)` will definitely breaks this rate. 
- Improve the polling efficiency. Instead of separately polling the 6bytes ADC data nad 1bytes status data, using continuous bytes reading method to get both raw ADC data and the status (6bytes -> 8bytes, 7th byte is a reserved empty byte). Besides, it is less important to get the  data_ready flag form `ST1`, since the data will keep the last values, which has same behavior with the previous sytle (i.e., skipping the data if it is not ready).

