### PR TITLE
[CAN][Spinal][Neuron] correct the tick to count 1 second

### DIFF
--- a/aerial_robot_nerve/neuron/neuronlib/CAN/can_device_manager.cpp
+++ b/aerial_robot_nerve/neuron/neuronlib/CAN/can_device_manager.cpp
@@ -53,7 +53,7 @@ namespace CANDeviceManager
     can_timeout_count++;
     if (can_timeout_count <= CAN_MAX_TIMEOUT_COUNT) {
       internal_count++;
-      if (internal_count == (1000 / cycle) - 1) {
+      if (internal_count == 1000 / cycle) {
         internal_count = 0;
       }
       if (internal_count == 0) {

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_device_manager.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/CAN/can_device_manager.cpp
@@ -55,7 +55,7 @@ namespace CANDeviceManager
     static int internal_count = 0;
     if (can_timeout_count <= CAN_MAX_TIMEOUT_COUNT) {
       internal_count++;
-      if (internal_count == (1000 / cycle) - 1) {
+      if (internal_count == 1000 / cycle) {
         internal_count = 0;
       }
       if (internal_count == 0) {


### PR DESCRIPTION
### What is this

The previous counter reset at 999ms, which is fixed by remove `-1`.
