### PR TITLE
[spinal][control] support multiple type of thrust motors

### DIFF
--- a/aerial_robot_nerve/spinal/CMakeLists.txt
+++ b/aerial_robot_nerve/spinal/CMakeLists.txt
@@ -37,6 +37,7 @@ add_message_files(
   RollPitchYawTerms.msg
   MotorInfo.msg
   PwmInfo.msg
+  PwmInfos.msg
   Pwms.msg
   PwmTest.msg
   UavInfo.msg

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
@@ -212,15 +212,7 @@ void AttitudeController::pwmsControl(void)
   /* nerve comm type */
 #if NERVE_COMM
   for(int i = 0; i < motor_number_; i++) {
-#if MOTOR_TEST
-
-    if (i == (HAL_GetTick() / 2000) % motor_number_)
-      Spine::setMotorPwm(200, i);
-    else
-      Spine::setMotorPwm(0, i);
-#else
     Spine::setMotorPwm(target_pwm_[i] * 2000 - 1000, i);
-#endif
   }
 #endif
 

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
@@ -202,7 +202,8 @@ private:
   float target_pwm_[MAX_MOTOR_NUMBER];
   float min_duty_[MAX_MOTOR_NUMBER];
   float max_duty_[MAX_MOTOR_NUMBER];
-  float min_thrust_[MAX_MOTOR_NUMBER]; // max thrust is variant according to the voltage
+  float min_thrust_[MAX_MOTOR_NUMBER];
+  float max_thrust_[MAX_MOTOR_NUMBER];
   float force_landing_thrust_[MAX_MOTOR_NUMBER];
   int8_t rotor_devider_;
   int8_t pwm_conversion_mode_[MAX_MOTOR_NUMBER];

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
@@ -64,8 +64,6 @@
 #define CONTROL_FEEDBACK_STATE_PUB_INTERVAL 25
 #define PWM_PUB_INTERVAL 100 //100ms
 
-#define MOTOR_TEST 0
-
 enum AXIS {
   X = 0,
   Y = 1,

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
@@ -46,6 +46,7 @@
 #include <spinal/FourAxisCommand.h>
 #include <spinal/RollPitchYawTerms.h>
 #include <spinal/PwmInfo.h>
+#include <spinal/PwmInfos.h>
 #include <spinal/UavInfo.h>
 #include <spinal/PMatrixPseudoInverseWithInertia.h>
 #include <spinal/TorqueAllocationMatrixInv.h>
@@ -136,7 +137,7 @@ private:
 
 #else
   ros::Subscriber<spinal::FourAxisCommand, AttitudeController> four_axis_cmd_sub_;
-  ros::Subscriber<spinal::PwmInfo, AttitudeController> pwm_info_sub_;
+  ros::Subscriber<spinal::PwmInfos, AttitudeController> pwm_info_sub_;
   ros::Subscriber<spinal::RollPitchYawTerms, AttitudeController> rpy_gain_sub_;
   ros::Subscriber<spinal::PwmTest, AttitudeController> pwm_test_sub_;
   ros::Subscriber<spinal::PMatrixPseudoInverseWithInertia, AttitudeController> p_matrix_pseudo_inverse_inertia_sub_;
@@ -199,22 +200,22 @@ private:
   // Thrust PWM Conversion
   float target_thrust_[MAX_MOTOR_NUMBER];
   float target_pwm_[MAX_MOTOR_NUMBER];
-  float min_duty_;
-  float max_duty_;
-  float min_thrust_; // max thrust is variant according to the voltage
-  float force_landing_thrust_;
+  float min_duty_[MAX_MOTOR_NUMBER];
+  float max_duty_[MAX_MOTOR_NUMBER];
+  float min_thrust_[MAX_MOTOR_NUMBER]; // max thrust is variant according to the voltage
+  float force_landing_thrust_[MAX_MOTOR_NUMBER];
   int8_t rotor_devider_;
-  int8_t pwm_conversion_mode_;
-  std::vector<spinal::MotorInfo> motor_info_;
-  uint8_t motor_ref_index_;
-  float v_factor_;
+  int8_t pwm_conversion_mode_[MAX_MOTOR_NUMBER];
+  std::vector<std::vector<spinal::MotorInfo>> motor_info_;
+  uint8_t motor_ref_index_[MAX_MOTOR_NUMBER];
+  float v_factor_[MAX_MOTOR_NUMBER];
   uint32_t voltage_update_last_time_;
   uint32_t control_term_pub_last_time_, control_feedback_state_pub_last_time_;
   uint32_t pwm_pub_last_time_;
   float pwm_test_value_[MAX_MOTOR_NUMBER]; // PWM Test
 
   void fourAxisCommandCallback( const spinal::FourAxisCommand &cmd_msg);
-  void pwmInfoCallback( const spinal::PwmInfo &info_msg);
+  void pwmInfoCallback( const spinal::PwmInfos &info_msg);
   void rpyGainCallback( const spinal::RollPitchYawTerms &gain_msg);
   void pMatrixInertiaCallback(const spinal::PMatrixPseudoInverseWithInertia& msg);
   void torqueAllocationMatrixInvCallback(const spinal::TorqueAllocationMatrixInv& msg);

--- a/aerial_robot_nerve/spinal/msg/PwmInfos.msg
+++ b/aerial_robot_nerve/spinal/msg/PwmInfos.msg
@@ -1,0 +1,2 @@
+uint8[] motor_types # 0-indexed
+spinal/PwmInfo[] pwm_infos


### PR DESCRIPTION
### What is this
enable to use different type motors for thrust.

### Details
- add new message in spinal PwmInfos which have motor type array to specify motor if necessary. And it have motor_infos field to store all type of motors.
- update interface of spinal and aeiral_robot_control
- update saturation process implemented in attitude control of spinal considering each profile of motors

No change is needed if we use single type of motor.

### TODO
- [ ] check with real machine with single type of motor
- [ ] check with real machine with multiple types of motor