### PR TITLE
[ros-o] support one for ROS_DISTRO

### DIFF
--- a/aerial_robot_one.rosinstall
+++ b/aerial_robot_one.rosinstall
@@ -1,0 +1,1 @@
+aerial_robot_debian.rosinstall


### PR DESCRIPTION
### What is this
I'm using repositry https://github.com/ubi-agni/ros-builder-action to install ROS-O which is more active and continuously tested.
In this repositry, environment variabel $ROS_DISTRO is provided as `one` rather than `debian`.
So  I added symbolic link to resolve path. 