### PR TITLE
[aerial_robot_simulation] enable to publish odometry of arbitary frame from gazebo

### DIFF
--- a/aerial_robot_simulation/include/aerial_robot_simulation/aerial_robot_hw_sim.h
+++ b/aerial_robot_simulation/include/aerial_robot_simulation/aerial_robot_hw_sim.h
@@ -96,6 +96,17 @@ protected:
 #endif
   std::string baselink_parent_;
 
+  std::vector<std::string> additional_frames_;
+#if GAZEBO_MAJOR_VERSION > 8
+  std::map<std::string, ignition::math::Pose3d> additional_frame_offsets_;
+#else
+  std::map<std::string, gazebo::math::Pose> additional_frame_offsets_;
+#endif
+  std::map<std::string, std::string> additional_frame_parents_;
+
+  std::map<std::string, ros::Publisher> additional_frame_odom_pubs_;
+  std::map<std::string, ros::Time> additional_frame_last_pub_times_;
+
   double start_t_;
   double spinal_init_wait_time_;
 


### PR DESCRIPTION
### What is this
enable to publish odometry of arbitary frame from gazebo

### Details
Please set frame names as follows
```
simulation:
  additional_frames: [link2]
```
Odometry of specified frame is published in `link2/ground_truth` with `nav_msgs/Odometry`.

### TODO
publish message with `geometry_msgs/PoseStamped` like as /mocap/pose
