### PR TITLE
[Mini Quadrotor] update the URDF with the 3D LiDAR CFRP protector

### DIFF
--- a/robots/mini_quadrotor/urdf/robot.urdf.xacro
+++ b/robots/mini_quadrotor/urdf/robot.urdf.xacro
@@ -106,7 +106,7 @@
   <!-- main_body -->
   <link name="main_body">
     <inertial>
-      <mass value = "0.832" /> 
+      <mass value = "0.860" />
       <origin xyz="0.002 0 ${0.028 - 0.002}" rpy="0 0 0"/> <!-- TODO: true cog pos -->
       <inertia
           ixx="0.0030" ixy="0" ixz="0"


### PR DESCRIPTION
### What is this

Increase the weight due to the addtional protector for 3D LiDAR.