### PR TITLE
[Estimation][SO3] fix the bug of the non-orthgonal problem of x axis vector when re-construct coorditate.

### DIFF
--- a/aerial_robot_estimation/src/state_estimation.cpp
+++ b/aerial_robot_estimation/src/state_estimation.cpp
@@ -106,6 +106,9 @@ void StateEstimator::setOrientationWxB(int frame, int estimate_mode, tf::Vector3
   tf::Vector3 wy_b = wz_b.cross(wx_b);
   wy_b.normalize();
 
+  wx_b = wy_b.cross(wz_b);
+  wx_b.normalize();
+
   rot[0] = wx_b; rot[1] = wy_b; rot[2] = wz_b;
 
   setOrientation(frame, estimate_mode, rot);
@@ -119,6 +122,9 @@ void StateEstimator::setOrientationWzB(int frame, int estimate_mode, tf::Vector3
   tf::Vector3 wx_b = rot.getRow(0);
   tf::Vector3 wy_b = wz_b.cross(wx_b);
   wy_b.normalize();
+
+  wx_b = wy_b.cross(wz_b);
+  wx_b.normalize();
 
   rot[0] = wx_b; rot[1] = wy_b; rot[2] = wz_b;
 


### PR DESCRIPTION
### What is this

Fix the bug of the non-orthgonal problem of the `x` axis vector when re-construct rotational matrix.

### Details

The `x` axis vector (`wb_x/wc_x`) is obtained from mocap or odometry, which might not be orthogonal wih the `z` axis vector  (`wb_z/wc_z`) obtained from IMU. Therefore it is necessary to re-construct orthogonal `x` axis vector by using the `y` and `z` vectors.