### PR TITLE
[aerial_robot_control] implement position navigation with root and baselink frame

### DIFF
--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -263,7 +263,36 @@ void BaseNavigator::naviCallback(const aerial_robot_msgs::FlightNavConstPtr & ms
     {
     case aerial_robot_msgs::FlightNav::POS_MODE:
       {
-        tf::Vector3 target_cog_pos(msg->target_pos_x, msg->target_pos_y, 0);
+        tf::Vector3 target_cog_pos;
+        if(msg->target == aerial_robot_msgs::FlightNav::BASELINK)
+          {
+            KDL::Vector w_r_fc_in_w = KDL::Vector(msg->target_pos_x, msg->target_pos_y, 0);
+            double target_cog_yaw = getTargetRPY().z();
+            KDL::Rotation w_R_cog = KDL::Rotation::RotZ(target_cog_yaw);
+            KDL::Vector fc_r_cog_in_fc = robot_model_->getCog2Baselink<KDL::Frame>().Inverse().p;
+            KDL::Rotation cog_R_fc = robot_model_->getCog2Baselink<KDL::Frame>().M;
+            KDL::Vector w_r_cog_in_w = w_r_fc_in_w + w_R_cog * cog_R_fc * fc_r_cog_in_fc;
+            target_cog_pos = tf::Vector3(w_r_cog_in_w.x(), w_r_cog_in_w.y(), 0);
+          }
+        else if(msg->target == aerial_robot_msgs::FlightNav::COG)
+          {
+            target_cog_pos = tf::Vector3(msg->target_pos_x, msg->target_pos_y, 0);
+          }
+        else if(msg->target == aerial_robot_msgs::FlightNav::ROOT)
+          {
+            KDL::Vector w_r_root_in_w = KDL::Vector(msg->target_pos_x, msg->target_pos_y, 0);
+            double target_cog_yaw = getTargetRPY().z();
+            KDL::Rotation w_R_cog = KDL::Rotation::RotZ(target_cog_yaw);
+            KDL::Vector root_r_cog_in_root = robot_model_->getCog<KDL::Frame>().p;
+            KDL::Rotation cog_R_root = robot_model_->getCog<KDL::Frame>().Inverse().M;
+            KDL::Vector w_r_cog_in_w = w_r_root_in_w + w_R_cog * cog_R_root * root_r_cog_in_root;
+            target_cog_pos = tf::Vector3(w_r_cog_in_w.x(), w_r_cog_in_w.y(), 0);
+          }
+        else
+          {
+            ROS_ERROR("the target type is not supported");
+            return;
+          }
 
         tf::Vector3 target_delta = getTargetPos() - target_cog_pos;
         target_delta.setZ(0);

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -240,6 +240,12 @@ void BaseNavigator::naviCallback(const aerial_robot_msgs::FlightNavConstPtr & ms
           double root_to_cog_z = -cog_H_root.p.z();
           target_cog_pos_z = msg->target_pos_z + root_to_cog_z;
         }
+      else
+        {
+          ROS_ERROR("the target type is not supported");
+          return;
+        }
+
       setTargetPosZ(target_cog_pos_z);
       setTargetVelZ(0);
     }

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -222,7 +222,25 @@ void BaseNavigator::naviCallback(const aerial_robot_msgs::FlightNavConstPtr & ms
     }
   else if(msg->pos_z_nav_mode == aerial_robot_msgs::FlightNav::POS_MODE)
     {
-      setTargetPosZ(msg->target_pos_z);
+      double target_cog_pos_z;
+      if(msg->target == aerial_robot_msgs::FlightNav::BASELINK)
+        {
+          KDL::Frame cog_H_baselink = robot_model_->getCog2Baselink<KDL::Frame>(); // assuming target cog frame is horizontal in the world frame
+          double baselink_to_cog_z = -cog_H_baselink.p.z();
+          target_cog_pos_z = msg->target_pos_z + baselink_to_cog_z;
+        }
+      else if(msg->target == aerial_robot_msgs::FlightNav::COG)
+        {
+          target_cog_pos_z = msg->target_pos_z;
+        }
+
+      else if(msg->target == aerial_robot_msgs::FlightNav::ROOT)
+        {
+          KDL::Frame cog_H_root = robot_model_->getCog<KDL::Frame>().Inverse(); // assuming target cog frame is horizontal in the world frame
+          double root_to_cog_z = -cog_H_root.p.z();
+          target_cog_pos_z = msg->target_pos_z + root_to_cog_z;
+        }
+      setTargetPosZ(target_cog_pos_z);
       setTargetVelZ(0);
     }
   else if(msg->pos_z_nav_mode == aerial_robot_msgs::FlightNav::POS_VEL_MODE)

--- a/aerial_robot_msgs/msg/FlightNav.msg
+++ b/aerial_robot_msgs/msg/FlightNav.msg
@@ -10,11 +10,12 @@ uint8 LOCAL_FRAME = 1
 
 uint8 BASELINK = 0
 uint8 COG = 1
+uint8 ROOT = 2
 
 Header header
 
 uint8 control_frame # reference frame: local or world, mainly for vel/acc nav
-uint8 target # the target link: baselink or COG
+uint8 target # the target link: baselink or COG or ROOT
 uint8 pos_xy_nav_mode
 float64 target_pos_x
 float32 target_vel_x


### PR DESCRIPTION
### What is this
enable to send position command to baselink and rootlink

### Details
- add ROOT to `aerial_robot_msgs/FlightNav`
- implement convertion from target frame to cog
<img width="3024" height="4032" alt="IMG_2900" src="https://github.com/user-attachments/assets/851b6aa0-12db-48e7-b080-912a4e982423" />


### TODO
implement other modes (vel, pos_vel)